### PR TITLE
plugins sources: prevent errors because of non declared 'printf'

### DIFF
--- a/source/BBCut2UGens/BBCut2UGens.cpp
+++ b/source/BBCut2UGens/BBCut2UGens.cpp
@@ -37,6 +37,7 @@
 
 #include "SC_PlugIn.h"
 #include "SC_fftlib.h"
+#include <stdio.h>
 
 //helpful constants
 //#define PI 3.1415926535898f

--- a/source/ConcatUGens/Concat.cpp
+++ b/source/ConcatUGens/Concat.cpp
@@ -36,7 +36,7 @@
 //#include <string.h>
 //#include <math.h>
 //#include <stdlib.h>
-//#include <stdio.h>
+#include <stdio.h>
 
 static InterfaceTable *ft;
 

--- a/source/JoshUGens/JoshGrainUGens.cpp
+++ b/source/JoshUGens/JoshGrainUGens.cpp
@@ -28,6 +28,7 @@
 
 
 #include "SC_PlugIn.h"
+#include <stdio.h>
 
 // macros to put rgen state in registers
 #define RGET \

--- a/source/MCLDUGens/MCLDFFTUGens.cpp
+++ b/source/MCLDUGens/MCLDFFTUGens.cpp
@@ -22,6 +22,7 @@ FFT analysis and phase vocoder UGens for SuperCollider, by Dan Stowell.
 #include "SC_fftlib.h"
 #include "SC_PlugIn.h"
 #include "FFT_UGens.h"
+#include <stdio.h>
 
 // Used by PV_MagLog
 #define SMALLEST_NUM_FOR_LOG 2e-42

--- a/source/MCLDUGens/MCLDSparseUGens.cpp
+++ b/source/MCLDUGens/MCLDSparseUGens.cpp
@@ -1,4 +1,5 @@
 #include "SC_PlugIn.h"
+#include <stdio.h>
 
 // realtime Matching Pursuit ugen
 // (c) Dan Stowell 2012. All rights reserved.

--- a/source/NCAnalysisUGens/SMS.cpp
+++ b/source/NCAnalysisUGens/SMS.cpp
@@ -46,6 +46,7 @@
 
 
 #include "NCAnalysis.h"
+#include <stdio.h>
 
 //#include "FFT_UGens.h"
 //

--- a/source/NCAnalysisUGens/TPV.cpp
+++ b/source/NCAnalysisUGens/TPV.cpp
@@ -42,6 +42,7 @@
 
 //const int g_maxpeaks = 80;
 #include "NCAnalysis.h"
+#include <stdio.h>
 
 
 //cubic interpolation of phase parameters for formula (37) where t is from 0 to 1 as interpolation parameter

--- a/source/SLUGens/SLUGens.cpp
+++ b/source/SLUGens/SLUGens.cpp
@@ -22,6 +22,7 @@
 //SLUGens released under the GNU GPL as extensions for SuperCollider 3, by Nick Collins, http://www.informatics.sussex.ac.uk/users/nc81/
 
 #include "SC_PlugIn.h"
+#include <stdio.h>
 
 //#define SLUGENSRESEARCH 1
 

--- a/source/TagSystemUGens/TagSystemUgens.cpp
+++ b/source/TagSystemUGens/TagSystemUgens.cpp
@@ -24,6 +24,7 @@
 */
 
 #include "SC_PlugIn.h"
+#include <stdio.h>
 
 #ifndef MAXFLOAT
 # include <float.h>

--- a/source/VBAPUGens/VBAP.cpp
+++ b/source/VBAPUGens/VBAP.cpp
@@ -71,6 +71,7 @@ use or for distribution:
 #include "SC_PlugIn.h"
 #include <cmath>
 #include <limits>
+#include <stdio.h>
 
 #ifdef NOVA_SIMD
 #include "simd_memory.hpp"


### PR DESCRIPTION
Using `gcc-4.8.1` on `Linux x230 3.9.9-1-ARCH #1 SMP PREEMPT`, this fixes a bunch of:

> error: ‘printf’ was not declared in this scope
