### PR TITLE
FFTCrest.schelp: removed empty "related::"

### DIFF
--- a/source/MCLDUGens/sc/HelpSource/Classes/FFTCrest.schelp
+++ b/source/MCLDUGens/sc/HelpSource/Classes/FFTCrest.schelp
@@ -1,7 +1,6 @@
 CLASS:: FFTCrest
 summary:: Spectral crest measure
 categories:: UGens>Analysis, UGens>FFT
-related:: 
 
 DESCRIPTION::
 Given an FFT chain, this produces the spectral crest measure, which is an indicator of the "peakiness" of the spectral energy distribution. For example, white noise should produce a flat (non-peaky) spectrum, and therefore a low value for the spectral crest.


### PR DESCRIPTION
an empty related:: field apparently causes an error msg when help doc is indexed.
