### PR TITLE
Build a compressed DMG rather than read-write.

### DIFF
--- a/osx_package/CMakeOSXBundle.cmake
+++ b/osx_package/CMakeOSXBundle.cmake
@@ -7,5 +7,5 @@ execute_process(COMMAND cp "${osx_readme}" "${CMAKE_INSTALL_PREFIX}/README.txt"
                 COMMAND cp "${license}" "${CMAKE_INSTALL_PREFIX}"
                 COMMAND hdiutil create
                             -srcfolder "${CMAKE_INSTALL_PREFIX}"
-                            -format "UDRW" -volname "SC3-plugins"
+                            -format "UDZO" -volname "SC3-plugins"
                             "${CMAKE_INSTALL_PREFIX}/SC3ExtPlugins.dmg")


### PR DESCRIPTION
I noticed that the plugins get distributed as a read/write DMG for OS X, which is non-standard. Normally people distribute DMGs as compressed read-only.

`hdiutil` actually creates compressed, read-only DMGs by default, but in this case I specified it explicitly with the `UDZO` option rather than `UDRW`. One side benefit is that the output DMG is about a sixth the size compared to the read/write image.

Thanks for your consideration!
