### PR TITLE
LPCFile.sc: loadToBuffer: Use existing bufnum, don't loadToSignal twice

### DIFF
--- a/source/JoshUGens/sc/classes/LPCFile.sc
+++ b/source/JoshUGens/sc/classes/LPCFile.sc
@@ -124,11 +124,14 @@ LPCFile : File {
 	loadToBuffer {
 		var c, numcycles, tmp;
 		c = Condition.new;
-		this.loadToSignal;
 		Routine.run{
+			this.server.sendMsg(\b_free, buffer);
 			this.server.sync(c);
 			this.loadToSignal;
-			tmp = Buffer.loadCollection(this.server, signal);
+			tmp = Buffer.alloc(this.server, signal.size, 1, bufnum: buffer);
+			this.server.sync(c);
+			tmp.loadCollection(signal, action: { c.unhang });
+			c.hang;
 			buffer = tmp.bufnum;
 			("LPC data loaded to buffer "++ buffer.asString).postln;
 			}

--- a/source/JoshUGens/sc/classes/LPCFile.sc
+++ b/source/JoshUGens/sc/classes/LPCFile.sc
@@ -202,7 +202,11 @@ LPCFile : File {
 		}
 
 	asUGenInput {^buffer}
-	free { this.server.sendMsg(\b_free, buffer); buffer = nil }
+	free {
+		this.server.sendMsg(\b_free, buffer);
+		this.server.bufferAllocator.free(buffer);
+		buffer = nil
+	}
 	bufnum {^buffer}
 	asControlInput { ^buffer }
 	}

--- a/source/JoshUGens/sc/classes/LPCFile.sc
+++ b/source/JoshUGens/sc/classes/LPCFile.sc
@@ -202,7 +202,7 @@ LPCFile : File {
 		}
 
 	asUGenInput {^buffer}
-	free {buffer.free}
+	free { this.server.sendMsg(\b_free, buffer); buffer = nil }
 	bufnum {^buffer}
 	asControlInput { ^buffer }
 	}


### PR DESCRIPTION
This fixes two issues in LPCFile:loadToBuffer:

1. `this.loadToSignal` was called twice, wasting CPU time.

2. LPCFile's `init` method reserves a buffer number, but then `loadToBuffer` uses `Buffer.loadCollection` -- which ignores the previously reserved bufnum and allocates a new one. The first one is never released back to theServer.bufferAllocator, so... the class leaks buffer numbers.

Now, LPCFile will keep using the same buffer number that was allocated at first.