### PR TITLE
plugins: MdaPiano: Round midi note number before integer conversion

### DIFF
--- a/source/MdaUGens/MdaUGens.cpp
+++ b/source/MdaUGens/MdaUGens.cpp
@@ -116,7 +116,7 @@ void MdaPiano_next(MdaPiano *unit, int inNumSamples)
 		int32 k, s;
 		
 		// NOTE ON
-		note = sc_cpsmidi(freq);
+		note = sc_round(sc_cpsmidi(freq), 1.f);
 		if(!(note>0)) note = 0; // Added & phrased to guard against NaNs, should also catch negs
 		unit->note = note;
 		


### PR DESCRIPTION
I will admit that I haven't tested this, because I'm having the same build problems locally that others have reported, and I don't have time this morning to sort all of that out. But this seems fairly straightforward.

    SynthDef(\help_mdapiano, { |out=0, freq=440, gate=1|
        var son = MdaPiano.ar(freq, gate, release: 0.9, stereo: 0.3, sustain: 0);
        DetectSilence.ar(son, 0.01, doneAction:2);
        Out.ar(out, son * 0.1);
    }).add;
    
    (instrument: \help_mdapiano, freq: 261).play;

Without the fix, you'll hear B a semitone below middle C. With this fix, I expect you'll hear middle C. Since middle C is 261.6255653006 (A=440, 12 ET), I think it would make sense to hear the pitch that deviates from the given frequency by less than 5 cents, rather than nearly a semitone.

Note that this will have a large impact in Windows. Because (I presume) of differences in math library implementation, sc_cpsmidi often returns note numbers that are slightly too low (in Windows), causing truncation down to the next lower semitone. This doesn't happen in any Linux installation I've ever used, nor in OSX.