### PR TITLE
Add cmake arguments to .travis.yml that are tested on Mac and Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 before_install:
  - ifmac () { if [[ $TRAVIS_OS_NAME == osx ]]; then eval $@; fi; }
  - iflin () { if [[ $TRAVIS_OS_NAME == linux ]]; then eval $@; fi; }
+ - ifmac brew update
  - ifmac brew install cmake || true
  - iflin sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
  - iflin sudo add-apt-repository -y ppa:andykimpe/cmake  # backport of cmake 2.8.12
@@ -24,7 +25,8 @@ before_install:
 before_script:
  - mkdir BUILD
  - cd BUILD
- - cmake -DCMAKE_INSTALL_PREFIX:PATH=$PWD/SC3plugins -DCMAKE_BUILD_TYPE=Release -DSC_PATH=../supercollider ..
+ - ifmac cmake -DCMAKE_INSTALL_PREFIX:PATH=$PWD/SC3plugins -DIN_PLACE_BUILD=OFF -DCMAKE_BUILD_TYPE=Release -DSC_PATH=../supercollider -DCMAKE_OSX_DEPLOYMENT_TARGET=10.7 -DCPP11=ON ..
+ - iflin cmake -DCMAKE_INSTALL_PREFIX:PATH=$PWD/SC3plugins -DCMAKE_BUILD_TYPE=Release -DSC_PATH=../supercollider -DCPP11=ON ..
 
 script:
  - make install


### PR DESCRIPTION
I added cmake arguments that work on a Mac 10.10 and Ubuntu 14.04

Problems:
- BhobUgens currently break the build (see issue)
- Linux install insists on an linux file system logic, so it will install to
    `share/SuperCollider/Extensions/SC3...`
    starting from the CMAKE_PREFIX_PATH  
    I didn't understand how this is handled in the SC travis script, but it's not used here anyways atm

Note: 
- on Mac if you specify a cmake prefix path you must add IN_PLACE_BUILD=OFF
- CPP11=ON is required now
- I think the CMakeLists.txt needs an overhaul, but I didn't change anything, just added cmake-arguments