### PR TITLE
remove duplicate classes in DEINDUGens

### DIFF
--- a/source/DEINDUGens/faust_src/Greyhole.sc
+++ b/source/DEINDUGens/faust_src/Greyhole.sc
@@ -1,1 +1,0 @@
-../sc/Greyhole.sc

--- a/source/DEINDUGens/faust_src/JPverb.sc
+++ b/source/DEINDUGens/faust_src/JPverb.sc
@@ -1,1 +1,0 @@
-../sc/JPverb.sc


### PR DESCRIPTION
Fixes #43. It's useful in documentation work to point SC directly to the source folder like in these instructions: http://supercollider.github.io/contributing/ideconfig-contrib