### PR TITLE
BerlachUGens: get oversampling ugens working for blocksize > 64

### DIFF
--- a/source/BerlachUGens/BerlachUGens.cpp
+++ b/source/BerlachUGens/BerlachUGens.cpp
@@ -181,7 +181,6 @@ void SoftClipAmp4_Dtor(SoftClipAmp4 *unit);
 void SoftClipAmp4_next(SoftClipAmp4 *unit, int inNumSamples);
 
 void DriveNoise_Ctor(DriveNoise *unit);
-void DriveNoise_Dtor(DriveNoise *unit);
 void DriveNoise_next(DriveNoise *unit, int inNumSamples);
 
 }
@@ -1132,6 +1131,12 @@ OSWrap4_Ctor (OSWrap4 *unit)
 }
 
 void
+OSWrap4_Dtor (OSWrap4 *unit)
+{
+  OVERSAMPLE_DTOR;
+}
+
+void
 OSWrap4_next (OSWrap4 *unit, int inNumSamples)
 {
   float *out = ZOUT(0);
@@ -1316,18 +1321,18 @@ PluginLoad(Berlach)
   DefineSimpleUnit(LPFVS6);
   DefineSimpleUnit(LPF1);
   DefineSimpleUnit(BLBufRd);
-  DefineSimpleUnit(OSWrap4);
-  DefineSimpleUnit(OSWrap8);
-  DefineSimpleUnit(OSTrunc4);
-  DefineSimpleUnit(OSTrunc8);
-  DefineSimpleUnit(OSFold4);
-  DefineSimpleUnit(OSFold8);
-  DefineSimpleUnit(Clipper8);
-  DefineSimpleUnit(Clipper4);
-  DefineSimpleUnit(SoftClipper8);
-  DefineSimpleUnit(SoftClipper4);
-  DefineSimpleUnit(SoftClipAmp8);
-  DefineSimpleUnit(SoftClipAmp4);
+  DefineDtorUnit(OSWrap4);
+  DefineDtorUnit(OSWrap8);
+  DefineDtorUnit(OSTrunc4);
+  DefineDtorUnit(OSTrunc8);
+  DefineDtorUnit(OSFold4);
+  DefineDtorUnit(OSFold8);
+  DefineDtorUnit(Clipper8);
+  DefineDtorUnit(Clipper4);
+  DefineDtorUnit(SoftClipper8);
+  DefineDtorUnit(SoftClipper4);
+  DefineDtorUnit(SoftClipAmp8);
+  DefineDtorUnit(SoftClipAmp4);
   DefineSimpleUnit(DriveNoise);
 
 

--- a/source/BerlachUGens/BerlachUGens.cpp
+++ b/source/BerlachUGens/BerlachUGens.cpp
@@ -133,42 +133,55 @@ void BLBufRd_next(BLBufRd *unit, int inNumSamples);
 
 
 void OSWrap8_Ctor(OSWrap8 *unit);
+void OSWrap8_Dtor(OSWrap8 *unit);
 void OSWrap8_next(OSWrap8 *unit, int inNumSamples);
 
 void OSWrap4_Ctor(OSWrap4 *unit);
+void OSWrap4_Dtor(OSWrap4 *unit);
 void OSWrap4_next(OSWrap4 *unit, int inNumSamples);
 
 void OSFold4_Ctor(OSFold4 *unit);
+void OSFold4_Dtor(OSFold4 *unit);
 void OSFold4_next(OSFold4 *unit, int inNumSamples);
 
 void OSFold8_Ctor(OSFold8 *unit);
+void OSFold8_Dtor(OSFold8 *unit);
 void OSFold8_next(OSFold8 *unit, int inNumSamples);
 
 void OSTrunc4_Ctor(OSTrunc4 *unit);
+void OSTrunc4_Dtor(OSTrunc4 *unit);
 void OSTrunc4_next(OSTrunc4 *unit, int inNumSamples);
 
 void OSTrunc8_Ctor(OSTrunc8 *unit);
+void OSTrunc8_Dtor(OSTrunc8 *unit);
 void OSTrunc8_next(OSTrunc8 *unit, int inNumSamples);
 
 void Clipper8_Ctor(Clipper8 *unit);
+void Clipper8_Dtor(Clipper8 *unit);
 void Clipper8_next(Clipper8 *unit, int inNumSamples);
 
 void Clipper4_Ctor(Clipper4 *unit);
+void Clipper4_Dtor(Clipper4 *unit);
 void Clipper4_next(Clipper4 *unit, int inNumSamples);
 
 void SoftClipper8_Ctor(SoftClipper8 *unit);
+void SoftClipper8_Dtor(SoftClipper8 *unit);
 void SoftClipper8_next(SoftClipper8 *unit, int inNumSamples);
 
 void SoftClipper4_Ctor(SoftClipper4 *unit);
+void SoftClipper4_Dtor(SoftClipper4 *unit);
 void SoftClipper4_next(SoftClipper4 *unit, int inNumSamples);
 
 void SoftClipAmp8_Ctor(SoftClipAmp8 *unit);
+void SoftClipAmp8_Dtor(SoftClipAmp8 *unit);
 void SoftClipAmp8_next(SoftClipAmp8 *unit, int inNumSamples);
 
 void SoftClipAmp4_Ctor(SoftClipAmp4 *unit);
+void SoftClipAmp4_Dtor(SoftClipAmp4 *unit);
 void SoftClipAmp4_next(SoftClipAmp4 *unit, int inNumSamples);
 
 void DriveNoise_Ctor(DriveNoise *unit);
+void DriveNoise_Dtor(DriveNoise *unit);
 void DriveNoise_next(DriveNoise *unit, int inNumSamples);
 
 }
@@ -892,6 +905,12 @@ Clipper8_Ctor (Clipper8 *unit)
 }
 
 void
+Clipper8_Dtor (Clipper8 *unit)
+{
+  OVERSAMPLE_DTOR;
+}
+
+void
 Clipper8_next (Clipper8 *unit, int inNumSamples)
 {
   float *out = ZOUT(0);
@@ -916,6 +935,12 @@ Clipper4_Ctor (Clipper4 *unit)
 {
   OVERSAMPLE4_INIT;
   SETCALC(Clipper4_next);
+}
+
+void
+Clipper4_Dtor (Clipper4 *unit)
+{
+  OVERSAMPLE_DTOR;
 }
 
 void
@@ -951,6 +976,12 @@ SoftClipper8_Ctor (SoftClipper8 *unit)
 }
 
 void
+SoftClipper8_Dtor (SoftClipper8 *unit)
+{
+  OVERSAMPLE_DTOR;
+}
+
+void
 SoftClipper8_next (SoftClipper8 *unit, int inNumSamples)
 {
   float *out = ZOUT(0);
@@ -974,6 +1005,12 @@ SoftClipper4_Ctor (SoftClipper4 *unit)
 {
   OVERSAMPLE4_INIT;
   SETCALC(SoftClipper4_next);
+}
+
+void
+SoftClipper4_Dtor (SoftClipper4 *unit)
+{
+  OVERSAMPLE_DTOR;
 }
 
 void
@@ -1033,6 +1070,12 @@ SoftClipAmp8_Ctor (SoftClipAmp8 *unit)
 }
 
 void
+SoftClipAmp8_Dtor (SoftClipAmp8 *unit)
+{
+  OVERSAMPLE_DTOR;
+}
+
+void
 SoftClipAmp8_next (SoftClipAmp8 *unit, int inNumSamples)
 {
   float *out = ZOUT(0);
@@ -1056,6 +1099,12 @@ SoftClipAmp4_Ctor (SoftClipAmp4 *unit)
 {
   OVERSAMPLE4_INIT;
   SETCALC(SoftClipAmp4_next);
+}
+
+void
+SoftClipAmp4_Dtor (SoftClipAmp4 *unit)
+{
+  OVERSAMPLE_DTOR;
 }
 
 void
@@ -1108,6 +1157,12 @@ OSWrap8_Ctor (OSWrap8 *unit)
 }
 
 void
+OSWrap8_Dtor (OSWrap8 *unit)
+{
+  OVERSAMPLE_DTOR;
+}
+
+void
 OSWrap8_next (OSWrap8 *unit, int inNumSamples)
 {
   float *out = ZOUT(0);
@@ -1133,6 +1188,12 @@ OSFold4_Ctor (OSFold4 *unit)
 }
 
 void
+OSFold4_Dtor (OSFold4 *unit)
+{
+  OVERSAMPLE_DTOR;
+}
+
+void
 OSFold4_next (OSFold4 *unit, int inNumSamples)
 {
   float *out = ZOUT(0);
@@ -1155,6 +1216,12 @@ OSFold8_Ctor (OSFold8 *unit)
 {
   OVERSAMPLE8_INIT;
   SETCALC(OSFold8_next);
+}
+
+void
+OSFold8_Dtor (OSFold8 *unit)
+{
+  OVERSAMPLE_DTOR;
 }
 
 void
@@ -1184,6 +1251,12 @@ OSTrunc4_Ctor (OSTrunc4 *unit)
 }
 
 void
+OSTrunc4_Dtor (OSTrunc4 *unit)
+{
+  OVERSAMPLE_DTOR;
+}
+
+void
 OSTrunc4_next (OSTrunc4 *unit, int inNumSamples)
 {
   float *out = ZOUT(0);
@@ -1205,6 +1278,12 @@ OSTrunc8_Ctor (OSTrunc8 *unit)
 {
   OVERSAMPLE8_INIT;
   SETCALC(OSTrunc8_next);
+}
+
+void
+OSTrunc8_Dtor (OSTrunc8 *unit)
+{
+  OVERSAMPLE_DTOR;
 }
 
 void

--- a/source/BerlachUGens/Oversamp.h
+++ b/source/BerlachUGens/Oversamp.h
@@ -4,21 +4,26 @@
 /* Macros and structs for oversampled SuperCollider Ugens */
 /* For an example of how to use this macros see the file Oversamp8.cpp */
 
-struct Oversamp3 : public Unit
-{
-	float m_domem[238];
-	float m_upmem[8];
-};
-
-
-#define OVERSAMPLE3_INIT\
-  memset(unit->m_domem, 0, sizeof(float)*238);\
+#define OVERSAMPLE_INIT(n,off)\
+  int domemsize = (n) * BUFLENGTH + (off);\
+  unit->m_domem = (float*)RTAlloc(unit->mWorld, sizeof(float)*domemsize);\
+  memset(unit->m_domem, 0, sizeof(float)*domemsize);\
   memset(unit->m_upmem, 0, sizeof(float)*8)
+
+#define OVERSAMPLE_DTOR\
+  RTFree(unit->mWorld, unit->m_domem)
 
 #define UPMEM(i) (upmem[i])
 #define DOMEMPUT(i) (domemoff[oversampidx+(i)])
 #define DOMEMGET(i) (domemoff[(oversampidx-(i))])
 
+struct Oversamp3 : public Unit
+{
+	float* m_domem;
+	float m_upmem[8];
+};
+
+#define OVERSAMPLE3_INIT OVERSAMPLE_INIT(3, 46)
 
 
 
@@ -75,12 +80,10 @@ struct Oversamp3 : public Unit
 struct Oversamp4 : public Unit
 {
 	float m_upmem[8];
-	float m_domem[302];
+	float* m_domem;
 };
 
-#define OVERSAMPLE4_INIT\
-  memset(unit->m_domem, 0, sizeof(float)*302);\
-  memset(unit->m_upmem, 0, sizeof(float)*8)
+#define OVERSAMPLE4_INIT OVERSAMPLE_INIT(4, 46)
 
 
 
@@ -160,12 +163,10 @@ struct Oversamp4 : public Unit
 struct Oversamp8 : public Unit
 {
 	float m_upmem[8];
-	float m_domem[584];
+	float* m_domem;
 };
 
-#define OVERSAMPLE8_INIT\
-  memset(unit->m_domem, 0, sizeof(float)*584);\
-  memset(unit->m_upmem, 0, sizeof(float)*8)
+#define OVERSAMPLE8_INIT OVERSAMPLE_INIT(8, 72)
 
 
 


### PR DESCRIPTION
Fix #9. Turns out it's not so bad.
