### PR TITLE
Trailing commas in these two help files.

### DIFF
--- a/source/JoshUGens/sc/HelpSource/Classes/PV_PlayBuf.schelp
+++ b/source/JoshUGens/sc/HelpSource/Classes/PV_PlayBuf.schelp
@@ -1,7 +1,7 @@
 TITLE:: PV_PlayBuf
 summary:: Plays FFT data to a memory buffer
 categories:: Libraries>JoshUGens, UGens>FFT
-related:: Classes/PV_RecordBuf, Classes/PV_BinPlayBuf, Classes/PV_BufRd, Classes/PV_BinBufRd,
+related:: Classes/PV_RecordBuf, Classes/PV_BinPlayBuf, Classes/PV_BufRd, Classes/PV_BinBufRd
 
 DESCRIPTION::
 PV_PlayBuf will play back FFT data stored to a buffer with link::Classes/PV_RecordBuf::.

--- a/source/JoshUGens/sc/HelpSource/Classes/PV_RecordBuf.schelp
+++ b/source/JoshUGens/sc/HelpSource/Classes/PV_RecordBuf.schelp
@@ -1,7 +1,7 @@
 TITLE:: PV_RecordBuf
 summary:: Records FFT data to a memory buffer
 categories:: Libraries>JoshUGens, UGens>FFT
-related:: Classes/PV_RecordBuf, Classes/PV_BinPlayBuf, Classes/PV_BufRd, Classes/PV_BinBufRd,
+related:: Classes/PV_RecordBuf, Classes/PV_BinPlayBuf, Classes/PV_BufRd, Classes/PV_BinBufRd
 
 
 DESCRIPTION::


### PR DESCRIPTION
This breaks my entire help system, (which seems like also an important bug in the SCIDE)