### PR TITLE
plugins: SwitchDelay should not limit delayfactor

### DIFF
--- a/source/RFWUGens/RFWUGens.cpp
+++ b/source/RFWUGens/RFWUGens.cpp
@@ -120,10 +120,6 @@ void SwitchDelay_next( SwitchDelay *unit, int inNumSamples ) {
         offset_timer = ENVLEN;
     }
 
-    // limit the delay multiplier to reasonable numbers
-    if(delayfactor < 0.) delayfactor = 0.;
-    if(delayfactor > 0.9) delayfactor = 0.9;
-
     for(i=0; i < inNumSamples; ++i) {
         recval = in[i];
         readval = buffer[readpos] + offset_current;


### PR DESCRIPTION
This is debatable: but this commit suggests that the delayfactor can be:

1. negative (you may want to emphasize only odd harmonics at an octave
lower)

2. equal or very close to one (you may want to have an infinite decay
time for a while, or with very short delaytimes, you may easily need a
factor more than the current 0.9)

This is an API change.