### PR TITLE
readme: make installation instructions friendlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,34 @@ To learn how to write your own plugins, see [example-plugins](https://github.com
 
 For community discussion and support see the [SuperCollider mailing lists](http://www.birmingham.ac.uk/facilities/BEAST/research/supercollider/mailinglist.aspx) and the [github issue tracker](https://github.com/supercollider/sc3-plugins/issues).
 
-## Release Downloads
+## Installation
 
-Compiled releases are available from the [GitHub release page](https://github.com/supercollider/sc3-plugins/releases). For older versions (2013), see the [Sourceforge project page](http://sourceforge.net/projects/sc3-plugins/files/).
+Releases are available from the [GitHub release page](https://github.com/supercollider/sc3-plugins/releases). For older versions (2013), see the [Sourceforge project page](http://sourceforge.net/projects/sc3-plugins/files/).
 
-## Binary install
-
-Copy the contents of the tarball/`dmg` to your SuperCollider extensions folder. Find it with evaluating
+Unzip the release and move it to your SuperCollider extensions folder. You can find it by evaluating
 
 ```supercollider
 Platform.userExtensionDir
 ```
 
-in SuperCollider. Alternatively, you may install the extensions system-wide by copying to
+in SuperCollider. To evaluate code in SuperCollder, put your cursor on the line of code and press `Cmd+Enter`
+(macOS) or `Ctrl+Enter`.  Alternatively, you may install the extensions system-wide by copying to
 
 ```supercollider
 Platform.systemExtensionDir
 ```
 
+The folder might not exist, so you may need to create it yourself. You can do this in your operating system's file
+explorer or from within SuperCollider by evaluating:
+
+```supercollider
+File.mkdir(Platform.userExtensionDir)
+```
+
+On some operating systems, these directories may be hard to find because they're in hidden folders.  You can open
+the user app support directory (where the Extensions folder is) with the menu item
+"File->Open user support directory". On macOS, you can open a finder window and press `Cmd+Shift+G` and enter the
+name of the directory.
 
 ## Compile from source
 


### PR DESCRIPTION
Fixes #176.

- merge "Release downloads" and "binary install"
- rename section "Installation"
- add info about how to evaluate code in SC
- add instructions about how to get to extensions dir and that you might need to create the folder

@yaxu I didn't change the text of the "GitHub release page" link. I'm not sure why that is confusing, and it also doesn't make grammatical sense to change it to "download latest version". If you can explain that I'd appreciate it.