### PR TITLE
gitignore build* instead of build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store
-build
+build*
 source/local/*.cpp
 source/local/*.scd
 source/local/*.sc


### PR DESCRIPTION
This matches https://github.com/supercollider/supercollider/blob/develop/.gitignore and helps when, like me, you are trying to manage several build folders at once.