### PR TITLE
VBAP: Fix stairstepping during modulation

### DIFF
--- a/source/VBAPUGens/VBAP.cpp
+++ b/source/VBAPUGens/VBAP.cpp
@@ -595,7 +595,10 @@ static inline_functions void VBAP_next_simd(VBAP *unit, int inNumSamples)
 				nova::times_vec_simd(out, in, nextchanamp, inNumSamples);
 		} else {
 			float chanampslope = CALCSLOPE(nextchanamp, chanamp);
-			nova::times_vec_simd(out, in, nextchanamp, inNumSamples);
+			for (int j = 0; j < inNumSamples; j++) {
+				out[j] = in[j] * chanamp;
+				chanamp += chanampslope;
+			}
 			unit->m_chanamp[i] = nextchanamp;
 		}
 	}


### PR DESCRIPTION
this fixes #122 and replaces #123. i'm kicking myself because i delayed on this an entire year and only just now realized how simple the bug was.

the problem was a failure to increment the channel gains by the slopes in the nova-simd version of the code.

```
~array = VBAPSpeakerArray(2, [-30, 30, 0, -110, 110]);
~buf = ~array.loadToBuffer;
{ VBAP.ar(5, DC.ar(1), ~buf.bufnum, Line.kr(0, 360, 0.05), 1.0, 0.0) }.plot(0.05);
```

before:

![vbap_before](https://user-images.githubusercontent.com/1211064/35747875-dc69bc56-0800-11e8-864b-f25466e5f297.png)

after:

![vbap_after](https://user-images.githubusercontent.com/1211064/35747885-e4c025e8-0800-11e8-9c40-ae12698f08ef.png)


