### PR TITLE
Create assets with a script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 build*
+package/*.tar.tgz
 source/local/*.cpp
 source/local/*.scd
 source/local/*.sc

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 build*
 package/*.tar.tgz
+package/*.asc
 source/local/*.cpp
 source/local/*.scd
 source/local/*.sc

--- a/package/create_package.sh
+++ b/package/create_package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Creates assets for sc3-plugins in the form of
-# 'sc3-plugins-Version-x.x.x.tar.gz' and moves the file to $HOME (macOS) the
-# repository's package folder (Linux).
+# 'sc3-plugins-Version-x.x.x.tar.gz' and moves the file to the repository's
+# package folder.
 # Requires a writable /tmp folder.
 
 set -euo pipefail
@@ -63,22 +63,33 @@ cleanup_source_dir() {
   rm -rf "${package_name}-Version-${version}"
 }
 
+print_help() {
+  echo "Usage: $0 -v <version tag>"
+  exit 1
+}
+
 upstream="https://github.com/supercollider/sc3-plugins"
 package_name="sc3-plugins"
 source_dir="/tmp"
 version=`date "+%Y-%m-%d"`
 output_dir=$(get_absolute_path $0)
 
-while getopts ":v:s" Option
-do
-  case $Option in
-    v ) version=$OPTARG
+if [ ${#@} -gt 0 ]; then
+  while getopts 'hv:' flag; do
+    case "${flag}" in
+      h) print_help
+          ;;
+      v) version=$OPTARG
+          ;;
+      *)
+        echo "Error! Try '${0} -h'."
+        exit 1
         ;;
-    s ) package_type="source"
-        ;;
-  esac
-done
-shift $(($OPTIND - 1))
+    esac
+  done
+else
+  print_help
+fi
 
 checkout_project
 checkout_external_libraries

--- a/package/create_package.sh
+++ b/package/create_package.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 get_absolute_path() {
-  echo $(dirname $(readlink -f "$0"))
+  echo "$(cd "$(dirname "$0")" && pwd -P)"
 }
 
 remove_source_dir(){
@@ -66,12 +66,8 @@ cleanup_source_dir() {
 upstream="https://github.com/supercollider/sc3-plugins"
 package_name="sc3-plugins"
 source_dir="/tmp"
-output_dir="$HOME"
-os=`uname`
 version=`date "+%Y-%m-%d"`
-if [ $os = "Linux" ]; then
-  output_dir=$(get_absolute_path $0)
-fi
+output_dir=$(get_absolute_path $0)
 
 while getopts ":v:s" Option
 do

--- a/package/create_package.sh
+++ b/package/create_package.sh
@@ -58,13 +58,20 @@ move_sources() {
   mv -v "${package_name}-Version-${version}.tar.tgz" "${output_dir}/"
 }
 
+sign_sources() {
+  cd "${output_dir}"
+  gpg2 --default-key "${signer}" \
+       --output "${package_name}-Version-${version}.tar.tgz.asc" \
+       --detach-sign "${package_name}-Version-${version}.tar.tgz"
+}
+
 cleanup_source_dir() {
   cd "${source_dir}"
   rm -rf "${package_name}-Version-${version}"
 }
 
 print_help() {
-  echo "Usage: $0 -v <version tag>"
+  echo "Usage: $0 -v <version tag> -s <signature email>"
   exit 1
 }
 
@@ -72,12 +79,17 @@ upstream="https://github.com/supercollider/sc3-plugins"
 package_name="sc3-plugins"
 source_dir="/tmp"
 version=`date "+%Y-%m-%d"`
+signer=""
+signature=0
 output_dir=$(get_absolute_path $0)
 
 if [ ${#@} -gt 0 ]; then
-  while getopts 'hv:' flag; do
+  while getopts 'hv:s:' flag; do
     case "${flag}" in
       h) print_help
+          ;;
+      s) signer=$OPTARG
+         signature=1
           ;;
       v) version=$OPTARG
           ;;
@@ -97,6 +109,9 @@ clean_sources
 rename_sources
 compress_sources
 move_sources
+if [ $signature -eq 1 ]; then
+  sign_sources
+fi
 cleanup_source_dir
 
 exit 0

--- a/package/create_package.sh
+++ b/package/create_package.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Creates assets for sc3-plugins
+# Requires: readlink (in coreutils package), git, access to /tmp
+
+set -euo pipefail
+
+get_absolute_path() {
+  echo $(dirname $(readlink -f "$0"))
+}
+
+create_source_dir(){
+  local abs_path="$1"
+  mkdir -pv "${abs_path}/source"
+  echo "${abs_path}/source"
+}
+
+remove_source_dir(){
+  echo "Removing potential previous sources."
+  rm -rf "${source_dir}/sc3-plugins"*
+}
+
+checkout_project() {
+  remove_source_dir
+  echo "Cloning project..."
+  cd "$source_dir"
+  git clone $upstream
+  echo "Checking out version: Version-$version"
+  cd "$package_name"
+  git checkout "Version-$version"
+}
+
+checkout_external_libraries() {
+  echo "Checking out external libraries..."
+  cd "${source_dir}/${package_name}"
+  git submodule update --init --recursive
+}
+
+clean_sources() {
+  cd "${source_dir}/${package_name}"
+  rm -rfv .gitigonre \
+          .git/ \
+          .travis.yml \
+          website
+}
+
+rename_sources() {
+  cd "${source_dir}"
+  mv -v "${package_name}" "${package_name}-Version-${version}"
+}
+
+compress_sources() {
+  cd "${source_dir}"
+  tar cvfz "${package_name}-Version-${version}.tar.tgz" \
+    "${package_name}-Version-${version}"
+}
+
+move_sources() {
+  cd "${source_dir}"
+  mv -v "${package_name}-Version-${version}.tar.tgz" "${abs_path}/"
+}
+
+upstream="https://github.com/supercollider/sc3-plugins"
+package_name="sc3-plugins"
+source_dir="/tmp"
+os=`uname`
+version=`date "+%Y-%m-%d"`
+abs_path=$(get_absolute_path $0)
+
+while getopts ":v:s" Option
+do
+  case $Option in
+    v ) version=$OPTARG
+        ;;
+    s ) package_type="source"
+        ;;
+  esac
+done
+shift $(($OPTIND - 1))
+
+checkout_project
+checkout_external_libraries
+clean_sources
+rename_sources
+compress_sources
+move_sources
+
+exit 0
+
+# vim:set ts=2 sw=2 et:

--- a/package/create_package.sh
+++ b/package/create_package.sh
@@ -10,7 +10,7 @@ get_absolute_path() {
   echo "$(cd "$(dirname "$0")" && pwd -P)"
 }
 
-remove_source_dir(){
+remove_source_dir() {
   echo "Removing potential previous sources."
   rm -rf "${source_dir}/sc3-plugins"*
 }
@@ -19,16 +19,7 @@ checkout_project() {
   remove_source_dir
   echo "Cloning project..."
   cd "$source_dir"
-  git clone $upstream
-  echo "Checking out version: Version-$version"
-  cd "$package_name"
-  git checkout "Version-$version"
-}
-
-checkout_external_libraries() {
-  echo "Checking out external libraries..."
-  cd "${source_dir}/${package_name}"
-  git submodule update --init --recursive
+  git clone $upstream --branch "Version-$version" --single-branch --recursive
 }
 
 clean_sources() {
@@ -104,7 +95,6 @@ else
 fi
 
 checkout_project
-checkout_external_libraries
 clean_sources
 rename_sources
 compress_sources


### PR DESCRIPTION
This is an attempt to fix #184 by creating a script, that can be called from anywhere.
It will use `/tmp` to create assets (in the form of `sc3-plugins-Version-x.x.x.tar.gz`) and then place the finished tarball beneath `package/`.

There is one pitfall: It uses `readlink -f` (see [get_absolute_path()](https://github.com/supercollider/sc3-plugins/compare/master...dvzrv:package?expand=1#diff-07e7b66d35e7dabd5131935313a81d3aR8)), which doesn't seem to be around under macOS by default, but can be installed with the coreutils package using homebrew or macports.

If you know of a valid alternative, let me know. As a workaround the script currently moves the tarball to $HOME on macOS and the package folder on Linux.

IMHO this is a much cleaner solution, than doing this in a potential working copy directly (as it is done in the SuperCollider repository).