### PR TITLE
Use HTTPS for nova-simd submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external_libraries/nova-simd"]
 	path = external_libraries/nova-simd
-	url = git://github.com/timblechmann/nova-simd.git
+	url = https://github.com/timblechmann/nova-simd.git
 [submodule "external_libraries/stk"]
 	path = external_libraries/stk
 	url = https://github.com/thestk/stk.git


### PR DESCRIPTION
The git protocol is unencrypted and susceptable to MITM attacks.
Simple change to use HTTPS instead of git as a protocol for the submodule. This way it's also the same for both submodules :)