### PR TITLE
Add QuantityUGens, MovingSum and MovingAverage

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -99,6 +99,7 @@ set(PLUGIN_DIRS
     MdaUGens
     Neuromodules
     NHUGens
+    QuantityUGens
     RFWUGens
     RMEQSuiteUGens
     SCMIRUGens

--- a/source/QuantityUGens/QuantityUGens.cpp
+++ b/source/QuantityUGens/QuantityUGens.cpp
@@ -1,22 +1,22 @@
 /*
-	SuperCollider real time audio synthesis system
-    Copyright (c) 2002 James McCartney. All rights reserved.
-	http://www.audiosynth.com
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
-*/
+ SuperCollider real time audio synthesis system
+ Copyright (c) 2002 James McCartney. All rights reserved.
+ http://www.audiosynth.com
+ 
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ */
 
 
 /*
@@ -28,30 +28,52 @@
  Authors:
  Michael McCrea, 2018, mtm5@uw.edu
  
-*/
+ */
 
 #include "SC_PlugIn.h"
 
 static InterfaceTable *ft;
 
-
-// MovingSum uses the underlying strategy of RunningSum
-// but adds a variable window size and a flag to average the output.
-struct MovingSum : public Unit {
+// MovingSum/Average uses the underlying strategy of RunningSum
+// but adds a variable window size.
+struct MovingX : public Unit {
     int nsamps, maxSamps, head, tail, resetCounter;
     float msum, msum2;
     bool reset;
     float* msquares;
 };
 
+struct MovingSum : public MovingX
+{};
+
+struct MovingAverage : public MovingX
+{};
+
 extern "C"
 {
     void MovingSum_Ctor(MovingSum *unit);
     void MovingSum_Dtor(MovingSum *unit);
     void MovingSum_next(MovingSum *unit, int inNumSamples);
+    
+    void MovingAverage_Ctor(MovingAverage *unit);
+    void MovingAverage_Dtor(MovingAverage *unit);
+    void MovingAverage_next(MovingAverage *unit, int inNumSamples);
+    
+    void MovingXCtorHelper(MovingX *unit, UnitCalcFunc calcFunc);
+    void MovingX_next(MovingX *unit, int inNumSamples, bool avg);
 }
 
 void MovingSum_Ctor( MovingSum* unit )
+{
+    MovingXCtorHelper(unit, (UnitCalcFunc)&MovingSum_next);
+}
+
+void MovingAverage_Ctor( MovingAverage* unit )
+{
+    MovingXCtorHelper(unit, (UnitCalcFunc)&MovingAverage_next);
+}
+
+inline void MovingXCtorHelper( MovingX* unit, UnitCalcFunc calcFunc )
 {
     if ((int) ZIN0(2) == 0) {
         printf("MovingSum Error: maxSamps initialized to 0.\n");
@@ -59,11 +81,11 @@ void MovingSum_Ctor( MovingSum* unit )
         unit->mDone = true;
         return;
     }
-
-    SETCALC(MovingSum_next);
-
+    
+    unit->mCalcFunc = calcFunc;
+    
     unit->maxSamps  = (int) ZIN0(2);
-    unit->nsamps    = sc_max(1, sc_min((int) ZIN0(1), unit->maxSamps)); // clip(1, maxSamps)
+    unit->nsamps    = sc_clip((int) ZIN0(1), 1, unit->maxSamps);
     unit->msum      = 0.0f;
     unit->msum2     = 0.0f;
     unit->resetCounter = 0;
@@ -71,7 +93,7 @@ void MovingSum_Ctor( MovingSum* unit )
     unit->tail      = unit->maxSamps - unit->nsamps;
     unit->reset     = false;
     unit->msquares  = (float*)RTAlloc(unit->mWorld, unit->maxSamps * sizeof(float));
-
+    
     if (unit->msquares == nullptr) {
         SETCALC(*ClearUnitOutputs);
         ClearUnitOutputs(unit, 1);
@@ -80,133 +102,147 @@ void MovingSum_Ctor( MovingSum* unit )
         }
         return;
     }
-
+    
     // zero the summing buffer
     for (int i=0; i < unit->maxSamps; ++i)
         unit->msquares[i] = 0.f;
-
+    
     ZOUT0(0) = 0.f;
 }
+
 
 void MovingSum_Dtor(MovingSum *unit)
 {
     RTFree(unit->mWorld, unit->msquares);
 }
+void MovingAverage_Dtor(MovingAverage *unit)
+{
+    RTFree(unit->mWorld, unit->msquares);
+}
+
 
 void MovingSum_next( MovingSum *unit, int inNumSamples )
+{
+    MovingX_next(unit, inNumSamples, false);
+}
+void MovingAverage_next( MovingAverage *unit, int inNumSamples )
+{
+    MovingX_next(unit, inNumSamples, true);
+}
+
+inline void MovingX_next( MovingX *unit, int inNumSamples, bool avg )
 {
     float *in   = ZIN(0);
     float *out  = ZOUT(0);
     float *data = unit->msquares;
-	
-	int newWinSize  = (int) ZIN0(1);  // number of samples to sum
+    
+    int newWinSize  = (int) ZIN0(1);  // number of samples to sum
     int prevWinSize = unit->nsamps;   // keep track of previous block's window size
-	int curWinSize  = unit->nsamps;   // keep track of window size as it ramps to new size
-	int maxWinSize  = unit->maxSamps;
-	
-	int head = unit->head;            // current write index in the rolling buffer
+    int curWinSize  = unit->nsamps;   // keep track of window size as it ramps to new size
+    int maxWinSize  = unit->maxSamps;
+    
+    int head = unit->head;            // current write index in the rolling buffer
     int tail = unit->tail;            // current tail  index in the rolling buffer
-	
+    
     float sum = unit->msum;
     float sum2 = unit->msum2;         // modeled after RunningSum - thanks to Ross Bencina
-	
-	int resetCounter = unit->resetCounter; // trigger sum<>sum2 swap
-	bool winSizeChanged = false;
-	float sampSlope = 0.0;
-	bool avg = ZIN0(3) > 0.0;         // output average flag
-	
-    newWinSize = sc_max(1, sc_min(newWinSize, maxWinSize)); // clamp [1, maxWinSize]
-	
-	if (newWinSize != prevWinSize) {
-		winSizeChanged = true;
-		sampSlope = CALCSLOPE( (float)newWinSize, prevWinSize );
-	}
-	
-	for (int i = 0; i < inNumSamples; ++i) {
-		
-		// handle change in summing window size
-		if (winSizeChanged) {
-			int steps = prevWinSize + (int)(sampSlope * (i+1)) - curWinSize;
-			
-			if (steps > 0) { // window grows
-				for (int j = 0; j < steps; ++j) {
-					tail--;
-					if (tail < 0)
-						tail += maxWinSize; // wrap
-					
-					sum += data[tail];
-					curWinSize++;
-					
-					if (resetCounter == curWinSize) {
-						sum = sum2;
-						resetCounter = 0;
-						sum2 = 0.0;
-					}
-				}
-			}
-			
-			if (steps < 0) { // window shrinks
-				for (int j = 0; j < abs(steps); ++j) {
-					sum -= data[tail];
-					tail++;
-					if (tail == maxWinSize)
-						tail = 0; // wrap
-					
-					curWinSize--;
-					if (resetCounter == curWinSize) {
-						sum = sum2;
-						resetCounter = 0;
-						sum2 = 0.0;
-					}
-				}
-			}
-				
-		}
-		
-		// remove last buffer sample
-		sum -= data[tail];
-		
-		// add and store new input sample
-		float next = ZXP(in);
-		data[head]= next;
-		sum += next;
-		sum2 += next;
-		
-		// write out
-		if (avg) {
-			ZXP(out) = sum / curWinSize;
-		} else {
-			ZXP(out) = sum;
-		}
-		
-		// increment and wrap the head and tail indices
-		head++;
-		if (head == maxWinSize)
-			head = 0;
-		
-		tail++;
-		if (tail == maxWinSize)
-			tail = 0;
-		
-		resetCounter++;
-		if (resetCounter == curWinSize) {
-			sum = sum2;
-			resetCounter = 0;
-			sum2 = 0.0;
-		}
-		
-		unit->nsamps = newWinSize;
-		unit->resetCounter = resetCounter;
-		unit->head  = head;
-		unit->tail  = tail;
-		unit->msum  = sum;
-		unit->msum2 = sum2;
-	}
+    
+    int resetCounter = unit->resetCounter; // trigger sum<>sum2 swap
+    bool winSizeChanged = false;
+    float sampSlope = 0.0;
+    
+    newWinSize = sc_clip(newWinSize, 1, maxWinSize);
+    
+    if (newWinSize != prevWinSize) {
+        winSizeChanged = true;
+        sampSlope = CALCSLOPE( (float)newWinSize, prevWinSize );
+    }
+    
+    for (int i = 0; i < inNumSamples; ++i) {
+        
+        // handle change in summing window size
+        if (winSizeChanged) {
+            int steps = prevWinSize + (int)(sampSlope * (i+1)) - curWinSize;
+            
+            if (steps > 0) { // window grows
+                for (int j = 0; j < steps; ++j) {
+                    tail--;
+                    if (tail < 0)
+                        tail += maxWinSize; // wrap
+                    
+                    sum += data[tail];
+                    curWinSize++;
+                    
+                    if (resetCounter == curWinSize) {
+                        sum = sum2;
+                        resetCounter = 0;
+                        sum2 = 0.0;
+                    }
+                }
+            }
+            
+            if (steps < 0) { // window shrinks
+                for (int j = 0; j < abs(steps); ++j) {
+                    sum -= data[tail];
+                    tail++;
+                    if (tail == maxWinSize)
+                        tail = 0; // wrap
+                    
+                    curWinSize--;
+                    if (resetCounter == curWinSize) {
+                        sum = sum2;
+                        resetCounter = 0;
+                        sum2 = 0.0;
+                    }
+                }
+            }
+        }
+        
+        // remove last buffer sample
+        sum -= data[tail];
+        
+        // add and store new input sample
+        float next = ZXP(in);
+        data[head]= next;
+        sum += next;
+        sum2 += next;
+        
+        // write out
+        if (avg) {
+            ZXP(out) = sum / curWinSize;
+        } else {
+            ZXP(out) = sum;
+        }
+        
+        // increment and wrap the head and tail indices
+        head++;
+        if (head == maxWinSize)
+            head = 0;
+        
+        tail++;
+        if (tail == maxWinSize)
+            tail = 0;
+        
+        resetCounter++;
+        if (resetCounter == curWinSize) {
+            sum = sum2;
+            resetCounter = 0;
+            sum2 = 0.0;
+        }
+        
+        unit->nsamps = newWinSize;
+        unit->resetCounter = resetCounter;
+        unit->head  = head;
+        unit->tail  = tail;
+        unit->msum  = sum;
+        unit->msum2 = sum2;
+    }
 }
 
 PluginLoad(QuantityUGens)
 {
-	ft = inTable; // store pointer to InterfaceTable
-	
+    ft = inTable; // store pointer to InterfaceTable
+    
     DefineDtorUnit(MovingSum);
+    DefineDtorUnit(MovingAverage);
 }

--- a/source/QuantityUGens/QuantityUGens.cpp
+++ b/source/QuantityUGens/QuantityUGens.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "SC_PlugIn.h"
+#include <limits.h>
 
 static InterfaceTable *ft;
 
@@ -75,12 +76,13 @@ void MovingAverage_Ctor( MovingAverage* unit )
 
 inline void MovingXCtorHelper( MovingX* unit, UnitCalcFunc calcFunc )
 {
-    if ((int) ZIN0(2) == 0) {
-        printf("MovingSum Error: maxSamps initialized to 0.\n");
-        SETCALC(*ClearUnitOutputs);
-        unit->mDone = true;
-        return;
-    }
+	if (((int) ZIN0(2) <= 0) || ((int) ZIN0(2) > INT_MAX) || sc_isnan(ZIN0(2)) || !sc_isfinite(ZIN0(2))) {
+		printf("MovingSum/Average Error: maxSamps argument is invalid: %f (<= 0, > INT_MAX, nan, or inf)\n", ZIN0(2));
+		SETCALC(*ClearUnitOutputs);
+		ClearUnitOutputs(unit, 1);
+		unit->mDone = true;
+		return;
+	}
     
     unit->mCalcFunc = calcFunc;
     

--- a/source/QuantityUGens/QuantityUGens.cpp
+++ b/source/QuantityUGens/QuantityUGens.cpp
@@ -1,0 +1,212 @@
+/*
+	SuperCollider real time audio synthesis system
+    Copyright (c) 2002 James McCartney. All rights reserved.
+	http://www.audiosynth.com
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+
+/*
+ 
+ UGens to aid in capturing audio and soundfield "quantities":
+ 
+ MovingSum
+ 
+ Authors:
+ Michael McCrea, 2018, mtm5@uw.edu
+ 
+*/
+
+#include "SC_PlugIn.h"
+
+static InterfaceTable *ft;
+
+
+// MovingSum uses the underlying strategy of RunningSum
+// but adds a variable window size and a flag to average the output.
+struct MovingSum : public Unit {
+    int nsamps, maxSamps, head, tail, resetCounter;
+    float msum, msum2;
+    bool reset;
+    float* msquares;
+};
+
+extern "C"
+{
+    void MovingSum_Ctor(MovingSum *unit);
+    void MovingSum_Dtor(MovingSum *unit);
+    void MovingSum_next(MovingSum *unit, int inNumSamples);
+}
+
+void MovingSum_Ctor( MovingSum* unit )
+{
+    if ((int) ZIN0(2) == 0) {
+        printf("MovingSum Error: maxSamps initialized to 0.\n");
+        SETCALC(*ClearUnitOutputs);
+        unit->mDone = true;
+        return;
+    }
+
+    SETCALC(MovingSum_next);
+
+    unit->maxSamps  = (int) ZIN0(2);
+    unit->nsamps    = sc_max(1, sc_min((int) ZIN0(1), unit->maxSamps)); // clip(1, maxSamps)
+    unit->msum      = 0.0f;
+    unit->msum2     = 0.0f;
+    unit->resetCounter = 0;
+    unit->head      = 0;    // first write position
+    unit->tail      = unit->maxSamps - unit->nsamps;
+    unit->reset     = false;
+    unit->msquares  = (float*)RTAlloc(unit->mWorld, unit->maxSamps * sizeof(float));
+
+    if (unit->msquares == nullptr) {
+        SETCALC(*ClearUnitOutputs);
+        ClearUnitOutputs(unit, 1);
+        if (unit->mWorld->mVerbosity > -2) {
+            printf("Failed to allocate memory for MovingSum\n");
+        }
+        return;
+    }
+
+    // zero the summing buffer
+    for (int i=0; i < unit->maxSamps; ++i)
+        unit->msquares[i] = 0.f;
+
+    ZOUT0(0) = 0.f;
+}
+
+void MovingSum_Dtor(MovingSum *unit)
+{
+    RTFree(unit->mWorld, unit->msquares);
+}
+
+void MovingSum_next( MovingSum *unit, int inNumSamples )
+{
+    float *in   = ZIN(0);
+    float *out  = ZOUT(0);
+    float *data = unit->msquares;
+	
+	int newWinSize  = (int) ZIN0(1);  // number of samples to sum
+    int prevWinSize = unit->nsamps;   // keep track of previous block's window size
+	int curWinSize  = unit->nsamps;   // keep track of window size as it ramps to new size
+	int maxWinSize  = unit->maxSamps;
+	
+	int head = unit->head;            // current write index in the rolling buffer
+    int tail = unit->tail;            // current tail  index in the rolling buffer
+	
+    float sum = unit->msum;
+    float sum2 = unit->msum2;         // modeled after RunningSum - thanks to Ross Bencina
+	
+	int resetCounter = unit->resetCounter; // trigger sum<>sum2 swap
+	bool winSizeChanged = false;
+	float sampSlope = 0.0;
+	bool avg = ZIN0(3) > 0.0;         // output average flag
+	
+    newWinSize = sc_max(1, sc_min(newWinSize, maxWinSize)); // clamp [1, maxWinSize]
+	
+	if (newWinSize != prevWinSize) {
+		winSizeChanged = true;
+		sampSlope = CALCSLOPE( (float)newWinSize, prevWinSize );
+	}
+	
+	for (int i = 0; i < inNumSamples; ++i) {
+		
+		// handle change in summing window size
+		if (winSizeChanged) {
+			int steps = prevWinSize + (int)(sampSlope * (i+1)) - curWinSize;
+			
+			if (steps > 0) { // window grows
+				for (int j = 0; j < steps; ++j) {
+					tail--;
+					if (tail < 0)
+						tail += maxWinSize; // wrap
+					
+					sum += data[tail];
+					curWinSize++;
+					
+					if (resetCounter == curWinSize) {
+						sum = sum2;
+						resetCounter = 0;
+						sum2 = 0.0;
+					}
+				}
+			}
+			
+			if (steps < 0) { // window shrinks
+				for (int j = 0; j < abs(steps); ++j) {
+					sum -= data[tail];
+					tail++;
+					if (tail == maxWinSize)
+						tail = 0; // wrap
+					
+					curWinSize--;
+					if (resetCounter == curWinSize) {
+						sum = sum2;
+						resetCounter = 0;
+						sum2 = 0.0;
+					}
+				}
+			}
+				
+		}
+		
+		// remove last buffer sample
+		sum -= data[tail];
+		
+		// add and store new input sample
+		float next = ZXP(in);
+		data[head]= next;
+		sum += next;
+		sum2 += next;
+		
+		// write out
+		if (avg) {
+			ZXP(out) = sum / curWinSize;
+		} else {
+			ZXP(out) = sum;
+		}
+		
+		// increment and wrap the head and tail indices
+		head++;
+		if (head == maxWinSize)
+			head = 0;
+		
+		tail++;
+		if (tail == maxWinSize)
+			tail = 0;
+		
+		resetCounter++;
+		if (resetCounter == curWinSize) {
+			sum = sum2;
+			resetCounter = 0;
+			sum2 = 0.0;
+		}
+		
+		unit->nsamps = newWinSize;
+		unit->resetCounter = resetCounter;
+		unit->head  = head;
+		unit->tail  = tail;
+		unit->msum  = sum;
+		unit->msum2 = sum2;
+	}
+}
+
+PluginLoad(QuantityUGens)
+{
+	ft = inTable; // store pointer to InterfaceTable
+	
+    DefineDtorUnit(MovingSum);
+}

--- a/source/QuantityUGens/sc/HelpSource/Classes/MovingAverage.schelp
+++ b/source/QuantityUGens/sc/HelpSource/Classes/MovingAverage.schelp
@@ -63,7 +63,7 @@ s.waitForBoot({
 	}).add;
 
 	// MovingAverage
-	SynthDef(\mvavg, { |out, in, samps=4410|
+	SynthDef(\mavg, { |out, in, samps=4410|
 		Out.kr( out,
 			A2K.kr(                // convert to control rate for scoping
 				MovingAverage.ar(  // average method
@@ -87,7 +87,7 @@ s.waitForBoot({
 ~noiSrc = Synth(\noisrc,  [\out, ~noiBus.index]);
 
 ~rs = Synth(\rs_avg,   [\out, ~avgBus.index,   \in, ~noiBus.index, \samps, 4410], addAction: 'addToTail');
-~mavg = Synth(\mvavg, [\out, ~avgBus.index+1, \in, ~noiBus.index, \samps, 4410], addAction: 'addToTail');
+~mavg = Synth(\mavg, [\out, ~avgBus.index+1, \in, ~noiBus.index, \samps, 4410], addAction: 'addToTail');
 )
 
 /* scope the results */

--- a/source/QuantityUGens/sc/HelpSource/Classes/MovingAverage.schelp
+++ b/source/QuantityUGens/sc/HelpSource/Classes/MovingAverage.schelp
@@ -1,0 +1,115 @@
+class:: MovingAverage
+summary:: The average of samples over a variable number of frames.
+related:: Classes/RunningSum, Classes/MovingSum
+categories:: UGens>Analysis, UGens>Maths
+
+description::
+A running average, power or RMS over a variable number of samples.
+For a running sum (not averaged) see link::Classes/MovingSum::.
+
+classmethods::
+method:: ar, kr
+Output the average of strong::numsamp:: audio or control rate samples.
+argument::in
+An input signal.
+argument::numsamp
+Size of the time window, in samples. Modulatable between 1 and
+strong::maxsamp::. Default: 40.
+argument::maxsamp
+Maximum size of the time window. Pre-allocates memory up to this size and
+your strong::numsamp:: will be clipped at this value. strong::maxsamp:: cannot
+be modulated.
+
+method:: power
+Output the time averaged power of the the signal. Implemented as the input
+squared, summed over the time window, averaged by the window size. The output
+rate is determined by the rate of the strong::in:: signal.
+
+method:: rms
+Output the root mean square (RMS) of the the signal. Implemented as the input
+squared, summed over the time window, averaged by the window size, and square
+rooted. The output rate is determined by the rate of
+the strong::in:: signal.
+
+examples::
+
+code::
+/*
+Compare the values of RunningSum vs. MovingAverage
+*/
+
+/* load synthdefs */
+(
+s.waitForBoot({
+
+	var maxWin = 1.0; // maximum summing/averaging window, in seconds.
+
+	// noise source: Pink Noise
+	SynthDef(\noisrc, { |out|
+		Out.ar(out, PinkNoise.ar);
+	}).add;
+
+	// RunningSum, averaged
+	SynthDef(\rs_avg, { |out, in, samps=4410|
+		Out.kr( out,
+			A2K.kr(                // convert to control rate for scoping
+				RunningSum.ar(
+					In.ar(in),
+					samps          // RunningSum samps is non-modulatable
+				)
+				* samps.reciprocal // take average
+			)
+		);
+	}).add;
+
+	// MovingAverage
+	SynthDef(\mvavg, { |out, in, samps=4410|
+		Out.kr( out,
+			A2K.kr(                // convert to control rate for scoping
+				MovingAverage.ar(  // average method
+					In.ar(in),
+					samps,
+					SampleRate.ir * maxWin  // max window size, in samples, non-modulatable
+				)
+			)
+		);
+	}).add;
+
+})
+)
+
+/* play the synths */
+(
+// A bus for the noise source
+~noiBus = Bus.audio(s, 1);
+~avgBus = Bus.control(s, 2);
+
+~noiSrc = Synth(\noisrc,  [\out, ~noiBus.index]);
+
+~rs = Synth(\rs_avg,   [\out, ~avgBus.index,   \in, ~noiBus.index, \samps, 4410], addAction: 'addToTail');
+~mavg = Synth(\mvavg, [\out, ~avgBus.index+1, \in, ~noiBus.index, \samps, 4410], addAction: 'addToTail');
+)
+
+/* scope the results */
+(
+var sv;
+~scp = s.scope(2, ~avgBus.index, rate:'control');
+~scp.style = 1; // overlay the busses to compare their values
+
+sv = ~scp.scopeView;
+
+sv.yZoom = 3; // zoom in to see values a bit better
+sv.fill = false;
+// discern different values by color: red is RunningSum2
+sv.waveColors = [Color.yellow, Color.red];
+)
+
+/* change window size */
+~mavg.set(\samps, 0.5 * s.sampleRate);  // 0.5s window size
+~mavg.set(\samps, 4410);                // identical to RunningSum fixed window size
+~mavg.set(\samps, 0.01 * s.sampleRate); // 0.01s window size
+
+/* cleanup */
+[~noiBus, ~avgBus, ~noiSrc, ~rs, ~mavg].do(_.free);
+~scp.quit;
+::

--- a/source/QuantityUGens/sc/HelpSource/Classes/MovingSum.schelp
+++ b/source/QuantityUGens/sc/HelpSource/Classes/MovingSum.schelp
@@ -1,0 +1,108 @@
+class:: MovingSum
+summary:: The sum of samples over a variable number of frames.
+related:: Classes/RunningSum, Classes/MovingAverage
+categories:: UGens>Analysis, UGens>Maths
+
+description::
+A running sum over a variable number of samples. Useful for time averaging
+operations. Also see link::Classes/MovingAverage::.
+
+classmethods::
+method:: ar, kr
+Output the sum of audio or control rate samples.
+argument::in
+An input signal.
+argument::numsamp
+Size of the summing window, in samples. Modulatable between 1 and
+strong::maxsamp::. Default: 40.
+argument::maxsamp
+Maximum size of the summing window. Pre-allocates memory up to this size and
+your strong::numsamp:: will be clipped at this value. strong::maxsamp:: cannot
+be modulated.
+argument::avg
+A flag specifying whether to output the average of the running sum over the
+strong::numsamp:: frames. code::0:: outputs the sum, code::> 0:: outputs the
+average. This is used internally by link::Classes/MovingAverage::.
+
+examples::
+
+code::
+/*
+Compare the values of RunningSum vs. MovingAverage, which uses MovingSum internally.
+*/
+
+/* load synthdefs */
+(
+s.waitForBoot({
+
+	var maxWin = 1.0; // maximum summing/averaging window, in seconds.
+
+	// noise source: Pink Noise
+	SynthDef(\noisrc, { |out|
+		Out.ar(out, PinkNoise.ar);
+	}).add;
+
+	// RunningSum, averaged
+	SynthDef(\rs_avg, { |out, in, samps=4410|
+		Out.kr( out,
+			A2K.kr(                // convert to control rate for scoping
+				RunningSum.ar(
+					In.ar(in),
+					samps          // RunningSum samps is non-modulatable
+				)
+				* samps.reciprocal // take average
+			)
+		);
+	}).add;
+
+	// MovingAverage, internally using the MovingSum avg=true flag
+	SynthDef(\mvavg, { |out, in, samps=4410|
+		Out.kr( out,
+			A2K.kr(                // convert to control rate for scoping
+				MovingAverage.ar(
+					In.ar(in),
+					samps,
+					SampleRate.ir * maxWin  // max window size, in samples, non-modulatable
+				)
+			)
+		);
+	}).add;
+
+})
+)
+
+/* play the synths */
+(
+// A bus for the noise source
+~noiBus = Bus.audio(s, 1);
+~avgBus = Bus.control(s, 2);
+
+~noiSrc = Synth(\noisrc,  [\out, ~noiBus.index]);
+
+~rs = Synth(\rs_avg,   [\out, ~avgBus.index,   \in, ~noiBus.index, \samps, 4410], addAction: 'addToTail');
+~mavg = Synth(\mvavg, [\out, ~avgBus.index+1, \in, ~noiBus.index, \samps, 4410], addAction: 'addToTail');
+)
+
+/* scope the results */
+(
+var sv;
+~scp = s.scope(2, ~avgBus.index, rate:'control');
+~scp.style = 1; // overlay the busses to compare their values
+
+sv = ~scp.scopeView;
+
+sv.yZoom = 3; // zoom in to see values a bit better
+sv.fill = false;
+// discern different values by color: red is RunningSum2
+sv.waveColors = [Color.yellow, Color.red];
+)
+
+/* change window size */
+~mavg.set(\samps, 0.5 * s.sampleRate);  // 0.5s window size
+~mavg.set(\samps, 4410);                // identical to RunningSum fixed window size
+~mavg.set(\samps, 0.01 * s.sampleRate); // 0.01s window size
+
+/* cleanup */
+[~noiBus, ~avgBus, ~noiSrc, ~rs, ~mavg].do(_.free);
+~scp.quit;
+::

--- a/source/QuantityUGens/sc/HelpSource/Classes/MovingSum.schelp
+++ b/source/QuantityUGens/sc/HelpSource/Classes/MovingSum.schelp
@@ -19,16 +19,12 @@ argument::maxsamp
 Maximum size of the summing window. Pre-allocates memory up to this size and
 your strong::numsamp:: will be clipped at this value. strong::maxsamp:: cannot
 be modulated.
-argument::avg
-A flag specifying whether to output the average of the running sum over the
-strong::numsamp:: frames. code::0:: outputs the sum, code::> 0:: outputs the
-average. This is used internally by link::Classes/MovingAverage::.
 
 examples::
 
 code::
 /*
-Compare the values of RunningSum vs. MovingAverage, which uses MovingSum internally.
+Compare the values of RunningSum vs. MovingSum.
 */
 
 /* load synthdefs */
@@ -39,10 +35,10 @@ s.waitForBoot({
 
 	// noise source: Pink Noise
 	SynthDef(\noisrc, { |out|
-		Out.ar(out, PinkNoise.ar);
+		Out.ar(out, PinkNoise.ar * 4410.reciprocal); // scale down to see on scope
 	}).add;
 
-	// RunningSum, averaged
+	// RunningSum
 	SynthDef(\rs_avg, { |out, in, samps=4410|
 		Out.kr( out,
 			A2K.kr(                // convert to control rate for scoping
@@ -50,16 +46,15 @@ s.waitForBoot({
 					In.ar(in),
 					samps          // RunningSum samps is non-modulatable
 				)
-				* samps.reciprocal // take average
 			)
 		);
 	}).add;
 
-	// MovingAverage, internally using the MovingSum avg=true flag
-	SynthDef(\mvavg, { |out, in, samps=4410|
+	// MovingSum
+	SynthDef(\msum, { |out, in, samps=4410|
 		Out.kr( out,
 			A2K.kr(                // convert to control rate for scoping
-				MovingAverage.ar(
+				MovingSum.ar(
 					In.ar(in),
 					samps,
 					SampleRate.ir * maxWin  // max window size, in samples, non-modulatable
@@ -75,18 +70,18 @@ s.waitForBoot({
 (
 // A bus for the noise source
 ~noiBus = Bus.audio(s, 1);
-~avgBus = Bus.control(s, 2);
+~sumBus = Bus.control(s, 2);
 
 ~noiSrc = Synth(\noisrc,  [\out, ~noiBus.index]);
 
-~rs = Synth(\rs_avg,   [\out, ~avgBus.index,   \in, ~noiBus.index, \samps, 4410], addAction: 'addToTail');
-~mavg = Synth(\mvavg, [\out, ~avgBus.index+1, \in, ~noiBus.index, \samps, 4410], addAction: 'addToTail');
+~rs = Synth(\rs_avg,   [\out, ~sumBus.index,   \in, ~noiBus.index, \samps, 4410], addAction: 'addToTail');
+~msum = Synth(\msum, [\out, ~sumBus.index+1, \in, ~noiBus.index, \samps, 4410], addAction: 'addToTail');
 )
 
 /* scope the results */
 (
 var sv;
-~scp = s.scope(2, ~avgBus.index, rate:'control');
+~scp = s.scope(2, ~sumBus.index, rate:'control');
 ~scp.style = 1; // overlay the busses to compare their values
 
 sv = ~scp.scopeView;
@@ -98,11 +93,11 @@ sv.waveColors = [Color.yellow, Color.red];
 )
 
 /* change window size */
-~mavg.set(\samps, 0.5 * s.sampleRate);  // 0.5s window size
-~mavg.set(\samps, 4410);                // identical to RunningSum fixed window size
-~mavg.set(\samps, 0.01 * s.sampleRate); // 0.01s window size
+~msum.set(\samps, 4410 * 2);   // 2x RunningSum window size
+~msum.set(\samps, 4410);       // identical to RunningSum fixed window size
+~msum.set(\samps, 4410 * 0.1); // 0.1x RunningSum window size
 
 /* cleanup */
-[~noiBus, ~avgBus, ~noiSrc, ~rs, ~mavg].do(_.free);
+[~noiBus, ~sumBus, ~noiSrc, ~rs, ~msum].do(_.free);
 ~scp.quit;
 ::

--- a/source/QuantityUGens/sc/MovingSum.sc
+++ b/source/QuantityUGens/sc/MovingSum.sc
@@ -7,24 +7,25 @@ Jo Anderson     j.anderson@ambisonictoolkit.net
 // A sum of samples over a variable rectangular window of time
 MovingSum : UGen {
 
-	*ar { arg in, numsamp=40, maxsamp=400, avg = 0;
-		^this.multiNew('audio', in, numsamp, maxsamp, avg);
+	*ar { arg in, numsamp=40, maxsamp=400;
+		^this.multiNew('audio', in, numsamp, maxsamp);
 	}
 
-	*kr { arg in, numsamp=40, maxsamp=400, avg = 0;
-		^this.multiNew('control', in, numsamp, maxsamp, avg);
+	*kr { arg in, numsamp=40, maxsamp=400;
+		^this.multiNew('control', in, numsamp, maxsamp);
 	}
 
 }
 
-MovingAverage {
+// An average of samples over a variable rectangular window of time
+MovingAverage : UGen {
 
 	*ar { arg in, numsamp=40, maxsamp=400;
-		^MovingSum.ar(in, numsamp, maxsamp, avg: 1)
+		^this.multiNew('audio', in, numsamp, maxsamp);
 	}
 
 	*kr { arg in, numsamp=40, maxsamp=400;
-		^MovingSum.kr(in, numsamp, maxsamp, avg: 1)
+		^this.multiNew('control', in, numsamp, maxsamp);
 	}
 
 	*power { arg in, numsamp=40, maxsamp=400;

--- a/source/QuantityUGens/sc/MovingSum.sc
+++ b/source/QuantityUGens/sc/MovingSum.sc
@@ -1,0 +1,40 @@
+/*
+Michael McCrea  mtm5@uw.edu
+Jo Anderson     j.anderson@ambisonictoolkit.net
+2018
+*/
+
+// A sum of samples over a variable rectangular window of time
+MovingSum : UGen {
+
+	*ar { arg in, numsamp=40, maxsamp=400, avg = 0;
+		^this.multiNew('audio', in, numsamp, maxsamp, avg);
+	}
+
+	*kr { arg in, numsamp=40, maxsamp=400, avg = 0;
+		^this.multiNew('control', in, numsamp, maxsamp, avg);
+	}
+
+}
+
+MovingAverage {
+
+	*ar { arg in, numsamp=40, maxsamp=400;
+		^MovingSum.ar(in, numsamp, maxsamp, avg: 1)
+	}
+
+	*kr { arg in, numsamp=40, maxsamp=400;
+		^MovingSum.kr(in, numsamp, maxsamp, avg: 1)
+	}
+
+	*power { arg in, numsamp=40, maxsamp=400;
+		^this.perform( UGen.methodSelectorForRate(in.rate),
+			in.squared, numsamp, maxsamp
+		)
+	}
+
+	*rms { arg in, numsamp=40, maxsamp=400;
+		^this.power(in, numsamp, maxsamp).sqrt
+	}
+
+}

--- a/source/QuantityUGens/sc/Tests/TestMovingSum.sc
+++ b/source/QuantityUGens/sc/Tests/TestMovingSum.sc
@@ -1,0 +1,43 @@
+// tests both RunningSum and MovingSum
+
+TestMovingSum : UnitTest {
+
+	test_runningSums {
+		var advance=true, testfuncs, testOutput, numTestSamps, sumWin = 30;
+
+		testfuncs = [
+			{ RunningSum.ar(DC.ar(1), sumWin) },
+			{ MovingSum.ar(DC.ar(1), sumWin, sumWin) }
+		];
+
+		this.bootServer(Server.default);
+
+		numTestSamps = Server.default.sampleRate / 2;
+
+		// ramp up to sumWin and hold that value through numTestSamps
+		testOutput = (1.0, 2 .. sumWin)++(numTestSamps - sumWin).asInt.collect{sumWin};
+
+		[RunningSum, MovingSum].do{ |ugen, i|
+
+			this.wait{advance};
+			advance = false;
+
+			testfuncs[i].loadToFloatArray(
+				0.5, // for some reason only 0.5 and 1 seem to work... no math, no vars
+				Server.default,
+				{ |data|
+					this.assertArrayFloatEquals(
+						data, testOutput, ugen.asString, within: 0.001, report:true
+					);
+					advance = true;
+				}
+			);
+		};
+
+		this.wait({advance}, "FAILED WAITING: RunningSum");
+	}
+}
+
+/*
+TestMovingSum.run
+*/


### PR DESCRIPTION
Add QuantityUGens, intended for analyzing signal/soundfield quantities. Currently just adds
MovingSum, which is a variation of RunningSum that includes a variable window size. Extended to time averaging by MovingAverage class and convenience methods *power and *rms. Help docs and unit test included.