### PR TITLE
[QuantityUGens] make use of Print

### DIFF
--- a/source/QuantityUGens/QuantityUGens.cpp
+++ b/source/QuantityUGens/QuantityUGens.cpp
@@ -79,7 +79,7 @@ inline void MovingXCtorHelper( MovingX* unit, UnitCalcFunc calcFunc )
     unit->msquares = nullptr; // in case we error out before msquares is assigned
     
     if (ZIN0(2) < 1 || ZIN0(2) > std::numeric_limits<int>::max() || !std::isfinite(ZIN0(2))) {
-        printf("MovingSum/Average Error:\n\t'maxsamp' argument must be >= 1, and within integer resolution.\n\tReceived: %f\n", ZIN0(2));
+        Print("MovingSum/Average Error:\n\t'maxsamp' argument must be >= 1, and within integer resolution.\n\tReceived: %f\n", ZIN0(2));
         SETCALC(*ClearUnitOutputs);
         ClearUnitOutputs(unit, 1);
         unit->mDone = true;


### PR DESCRIPTION
This fixes #216.

**QuantityUGens.cpp** made use of `printf` which caused build issues. This PR changes `printf` to `Print`.