### PR TITLE
Revert "appveyor: don't clone supercollider recursively"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,8 +37,7 @@ install:
 - cmd: git submodule update --init --recursive
 
 - cmd: echo "Get SuperCollider"
-# can shallow clone, no submodules needed (no supernova)
-- cmd: git clone --depth 1 https://github.com/supercollider/supercollider ../supercollider
+- cmd: git clone --recursive --depth 1 https://github.com/supercollider/supercollider ../supercollider
 
 # FFTW3, including lib prep
 - cmd: echo "Install fftw"


### PR DESCRIPTION
This reverts commit f2ec7aa3ab19b2cf0569755061ee958055859e40, which was an accidental commit to 3.10. I have changed the repo settings to disallow this in the future (it was previously possible for administrators to push directly)

Consider this an 'opposite PR' - if you think the original commit was worth keeping, leave a reject review and I'll close it. If you think it needed changes, approve this and i'll merge it and open a new PR.