### PR TITLE
Eliminate some clang warnings

### DIFF
--- a/source/BlackrainUGens/BlackrainUGens.cpp
+++ b/source/BlackrainUGens/BlackrainUGens.cpp
@@ -246,9 +246,9 @@ void AmplitudeMod_next(AmplitudeMod* unit, int inNumSamples)
 }
 
 static inline float saturate(float input) {
-#define _limit 0.95
-  float x1 = fabsf( input + _limit );
-  float x2 = fabsf( input - _limit );
+  const float limit = 0.95f;
+  float x1 = fabsf( input + limit );
+  float x2 = fabsf( input - limit );
   return 0.5 * (x1 - x2);
 }
 

--- a/source/JoshUGens/JoshGrainUGens.cpp
+++ b/source/JoshUGens/JoshGrainUGens.cpp
@@ -6735,7 +6735,7 @@ inline float grain_in_at(Unit* unit, int index, int offset)
 		return IN0(index);
 }
 
-
+#undef GRAIN_BUF
 #define GRAIN_BUF													\
 	const SndBuf *buf;												\
 	if (bufnum >= world->mNumSndBufs) {								\
@@ -6812,6 +6812,7 @@ static inline bool getGrainWin(Unit * unit, float wintype, SndBuf *& window, con
 	return true;
 }
 
+#undef GRAIN_LOOP_BODY_4
 #define GRAIN_LOOP_BODY_4										\
 		float amp = y1 * y1;									\
 		phase = sc_gloop(phase, loopMax);						\
@@ -6841,6 +6842,7 @@ static inline bool getGrainWin(Unit * unit, float wintype, SndBuf *& window, con
 		y2 = y1;												\
 		y1 = y0;
 
+#undef GRAIN_LOOP_BODY_2
 #define GRAIN_LOOP_BODY_2								\
 		float amp = y1 * y1;							\
 		phase = sc_gloop(phase, loopMax);				\

--- a/source/OteyPianoUGens/hammer.cpp
+++ b/source/OteyPianoUGens/hammer.cpp
@@ -38,10 +38,6 @@ StulovHammer :: StulovHammer(float f, float Fs, float m, float K, float p, float
 
 }
 
-Hammer :: ~Hammer() {
-}
-BanksHammer :: ~BanksHammer() {
-}
 void StulovHammer::trigger(float v){
   // this->v0 = v;
    this->v = v;

--- a/source/OteyPianoUGens/hammer.h
+++ b/source/OteyPianoUGens/hammer.h
@@ -29,7 +29,7 @@ struct UnitDelay{
 class Hammer {
 public:
   Hammer(float f, float Fs, float m, float K, float p, float Z, float alpha, float v0);
-  ~Hammer();
+  virtual ~Hammer() = default;
    void* operator new(size_t sz){
 		return RTAlloc(gWorld, sz);
 	}
@@ -55,7 +55,6 @@ class BanksHammer:public Hammer
 {
 public:
   BanksHammer(float f, float Fs, float m, float K, float p, float Z, float alpha, float v0);
-  ~BanksHammer();
   float load( float vin);
   void trigger(float v);
   float vh;
@@ -69,7 +68,6 @@ class StulovHammer:public Hammer
 {
 public:
   StulovHammer(float f, float Fs, float m, float K, float p, float Z, float alpha, float v0);
-  ~StulovHammer();
   float load( float vin);
   void trigger(float v);
   float upprev;

--- a/source/PitchDetection/Qitch.cpp
+++ b/source/PitchDetection/Qitch.cpp
@@ -191,7 +191,7 @@ void Qitch_Ctor(Qitch* unit)
 		unit->m_amps[i]= g_amps[i];
 	
 	uint32 ampbufnum = (uint32)ZIN0(4);
-	if (!((ampbufnum > world->mNumSndBufs) || ampbufnum<0)) {
+	if (ampbufnum < world->mNumSndBufs) {
 		SndBuf *buf2 = world->mSndBufs + ampbufnum; 
 		
 		bufsize = buf2->samples;

--- a/source/RFWUGens/RFWUGens.cpp
+++ b/source/RFWUGens/RFWUGens.cpp
@@ -183,7 +183,8 @@ void AverageOutput_next( AverageOutput *unit, int inNumSamples ) {
     }
 
 	for (i=0; i<inNumSamples; ++i) {
-        average = ((count * average) + *(in+i)) / ++count;
+        average = ((count * average) + *(in+i)) / (count + 1);
+        ++count;
         ZXP(out) = average;
 	}
 


### PR DESCRIPTION
Fix #180

- undefine redefined macros
-    undesired promotion to double
-    fix unsequenced modification of value
-    mark destructor virtual - avoids memory leak when deleting hammer object
-    remove tautological compare - also fix bug - potential read from unallocated buffer
-    remove tautological compare