### PR TITLE
increase kMaxSynthGrains in JoshGrainUGens

### DIFF
--- a/source/JoshUGens/JoshGrainUGens.cpp
+++ b/source/JoshUGens/JoshGrainUGens.cpp
@@ -87,7 +87,7 @@ struct WinGrainI
 
 const int kMaxGrains = 64;
 
-const int kMaxSynthGrains = 512;
+const int kMaxSynthGrains = 2048;
 
 struct MonoGrain : public Unit
 {


### PR DESCRIPTION
Occasionally I am running into exceeding the number of grains.
This just arbitrarily exceeds to maximum, but maybe there is a better way to do this?