### PR TITLE
Add missing cstdio import required for printf

### DIFF
--- a/source/NHUGens/NHHall.cpp
+++ b/source/NHUGens/NHHall.cpp
@@ -27,6 +27,7 @@ For more information, please refer to <http://unlicense.org>
 
 #include "nh_hall.hpp"
 #include "SC_PlugIn.hpp"
+#include <cstdio>
 
 static InterfaceTable* ft;
 


### PR DESCRIPTION
This change fixes this compilation failure:

source/NHUGens/NHHall.cpp: In constructor 'NHHall::NHHall()':
source/NHUGens/NHHall.cpp:56:13: error: 'printf' was not declared in this scope
   56 |             printf("Could not allocate real-time memory for NHHall\n");
      |             ^~~~~~
source/NHUGens/NHHall.cpp:30:1: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
   29 | #include "SC_PlugIn.hpp"
  +++ |+#include <cstdio>
   30 |
In file included from source/NHUGens/NHHall.cpp:28: