### PR TITLE
added a note about using sudo under linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ replace `/path/to/sc/` with the path to the SuperCollider source directory. That
 `../../supercollider` if you cloned both repositories in the same working directory.
 
 ```shell
+cd sc3-plugins
 mkdir build && cd build
 cmake -DSC_PATH=/path/to/sc/ ..
 cmake --build . --config Release
-# to install the plugins
+# to install the plugins - note: linux users likely need sudo
 cmake --build . --config Release --target install
 ```
 


### PR DESCRIPTION
and an extra 'cd sc3-plugins' to make sure users are in the right directory to begin with.
the sudo is needed to avoid the following error...
```
Install the project...
-- Install configuration: ""
-- Installing: /usr/local/share/SuperCollider/Extensions/SC3plugins/local
CMake Error at source/cmake_install.cmake:41 (file):
  file INSTALL cannot make directory
  "/usr/local/share/SuperCollider/Extensions/SC3plugins/local": No such file
  or directory
Call Stack (most recent call first):
  cmake_install.cmake:42 (include)


make: *** [Makefile:74: install
```