### PR TITLE
Remove postln from arAlgo

### DIFF
--- a/source/SkUGens/sc/FM7.sc
+++ b/source/SkUGens/sc/FM7.sc
@@ -311,7 +311,7 @@ FM7 : MultiOutUGen {
 	}
 	*arAlgo { | algo=0, ctlMatrix, feedback=0.0 |
 		var modMatrix, channels;
-		#modMatrix, channels = this.algoSpec(algo, feedback).postln;
+		#modMatrix, channels = this.algoSpec(algo, feedback);
 		^this.ar(ctlMatrix, modMatrix).slice(channels)
 	}
 


### PR DESCRIPTION
This removes a .postln from the *arAlgo method that must have been leftover from some debugging