### PR TITLE
Dfsm shouldn't always post

### DIFF
--- a/source/TagSystemUGens/sc/SymbolicMachines.sc
+++ b/source/TagSystemUGens/sc/SymbolicMachines.sc
@@ -5,12 +5,11 @@ Dfsm : DUGen {
 	classvar <>verbose = false;
 
 	*new { arg rules, n = 1, rgen;
-		^this.multiNewList(['demand', n, rgen ? Dwhite.new]
-			++ this.convertRules(rules))
+		^this.multiNewList(['demand', n, rgen ?? { Dwhite.new }] ++ this.convertRules(rules))
 	}
 
 	*convertRules { arg rules;
-		var states, nextStates, sizes, data, res;
+		var states, nextStates, sizes, data;
 
 		// if exit state not given, add one.
 		if(rules.size.odd) { rules = rules ++ 0.0 };
@@ -26,13 +25,8 @@ Dfsm : DUGen {
 		sizes = nextStates.collect { |x| x.asArray.size };
 		data = states ++ nextStates.flat;
 
-		res = [states.size] ++ sizes ++ data;
-		if(verbose) {
-			res.do { |x, i|
-				postf("% : %\n", i + 3, x.asCompileString)
-			}
-		};
-		^res
+		^[states.size] ++ sizes ++ data
+
 	}
 
 }

--- a/source/TagSystemUGens/sc/SymbolicMachines.sc
+++ b/source/TagSystemUGens/sc/SymbolicMachines.sc
@@ -1,6 +1,9 @@
 
 
 Dfsm : DUGen {
+
+	classvar <>verbose = false;
+
 	*new { arg rules, n = 1, rgen;
 		^this.multiNewList(['demand', n, rgen ? Dwhite.new]
 			++ this.convertRules(rules))
@@ -24,10 +27,12 @@ Dfsm : DUGen {
 		data = states ++ nextStates.flat;
 
 		res = [states.size] ++ sizes ++ data;
-		res.do { |x, i|
-			postf("% : %\n", i + 3, x.asCompileString)
+		if(verbose) {
+			res.do { |x, i|
+				postf("% : %\n", i + 3, x.asCompileString)
+			}
 		};
-		^res;
+		^res
 	}
 
 }

--- a/source/TagSystemUGens/sc/SymbolicMachines.sc
+++ b/source/TagSystemUGens/sc/SymbolicMachines.sc
@@ -2,8 +2,6 @@
 
 Dfsm : DUGen {
 
-	classvar <>verbose = false;
-
 	*new { arg rules, n = 1, rgen;
 		^this.multiNewList(['demand', n, rgen ?? { Dwhite.new }] ++ this.convertRules(rules))
 	}


### PR DESCRIPTION
Posting the rules gets particularly problematic when they are very large. You can switch it back on by setting `Dfsm.verbose = true`.