### PR TITLE
Add Github action for testing website builds

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,33 @@
+name: jekyll
+on:
+  # push: # for testing this action
+  pull_request:
+    paths:
+      - '_data/**'
+      - '.bundle/**'
+      - 'assets/**'
+      - 'index.*'
+      - '_config.yml'
+      - 'Gemfile*'
+      - 'README.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    name: 'jekyll build'
+    env:
+      # use BUNDLE_ env vars to set 'bundle config' options
+      # needs to be set for all steps
+      BUNDLE_FORCE_RUBY_PLATFORM: 'true' #  avoid platform mismatch for nokogiri
+    steps:
+    - name: checkout sc3-plugins
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: setup ruby and build
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler: 'Gemfile.lock'
+        bundler-cache: true # this will run bundle install
+


### PR DESCRIPTION
I've created a github action that runs `bundle install` for PRs and thus should give us heads up in case PRs updating jekyll dependencies break the website.
You can see it [running successfully on my fork](https://github.com/dyfer/sc3-plugins/actions/runs/1292536285), as well as [expectedly failing](https://github.com/dyfer/sc3-plugins/actions/runs/1292543572) when I manually specified an invalid version of one package in `Gemfile.lock`. For these runs I've temporarily made the action to run on all pushes; however here it is set to run on PRs only.

This PR does _not_ provide a way to preview changes made to the website.