### PR TITLE
GitHub actions: ccache and other improvements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,12 @@ on:
       - '**.schelp'
       - 'README'
       - 'LICENSE'
+      - '_data/**'
+      - '.bundle/**'
+      - 'assets/**'
+      - 'index.*'
+      - '_config.yml'
+      - 'Gemfile*'
   pull_request:
     paths-ignore:
       - '**.md'
@@ -16,6 +22,12 @@ on:
       - '**.schelp'
       - 'README'
       - 'LICENSE'
+      - '_data/**'
+      - '.bundle/**'
+      - 'assets/**'
+      - 'index.*'
+      - '_config.yml'
+      - 'Gemfile*'
 
 jobs:
   build:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,15 +34,15 @@ jobs:
             xcode-version: '10.3'
             deployment-target: '10.10'
             
-          - name: Windows-32bit-VS
             cmake-generator: 'Visual Studio 16 2019'
             cmake-arch: 'Win32'
+          - name: Windows-32bit
             os: windows-2019
             vcvars-script: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat'
             fftw-url: 'ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip'
             fftw-arch: 'X86'
             
-          - name: Windows-64bit-VS
+          - name: Windows-64bit
             os: windows-2019
             cmake-generator: 'Visual Studio 16 2019'
             cmake-arch: 'x64'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,22 +30,20 @@ jobs:
             
           - name: macOS
             os: macos-10.15
-            cmake-generator: 'Xcode'
+            cmake-flags: '-G Xcode'
             xcode-version: '10.3'
             deployment-target: '10.10'
             
-            cmake-generator: 'Visual Studio 16 2019'
-            cmake-arch: 'Win32'
           - name: Windows-32bit
             os: windows-2019
+            cmake-flags: '-G "Visual Studio 16 2019" -A Win32'
             vcvars-script: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat'
             fftw-url: 'ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip'
             fftw-arch: 'X86'
             
           - name: Windows-64bit
             os: windows-2019
-            cmake-generator: 'Visual Studio 16 2019'
-            cmake-arch: 'x64'
+            cmake-flags: '-G "Visual Studio 16 2019" -A x64'
             vcvars-script: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat'
             fftw-url: 'ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip'
             fftw-arch: 'X64'
@@ -103,9 +101,7 @@ jobs:
         MACOSX_DEPLOYMENT_TARGET: '${{ matrix.deployment-target }}'
       run: |
         mkdir $BUILD_PATH && cd $BUILD_PATH
-        GENERATOR="${{ matrix.cmake-generator }}"
-        ARCH="${{ matrix.cmake-arch }}"
-        cmake ${GENERATOR:+-G "$GENERATOR"} ${ARCH:+-A "$ARCH"} -D SC_PATH=$SC_SRC_PATH -D CMAKE_BUILD_TYPE=Release -D SUPERNOVA=ON -D CMAKE_INSTALL_PREFIX=$INSTALL_PATH -D IN_PLACE_BUILD=OFF -D CMAKE_OSX_DEPLOYMENT_TARGET=10.10 .. --debug-output
+        cmake ${{ matrix.cmake-flags }} -D SC_PATH=$SC_SRC_PATH -D CMAKE_BUILD_TYPE=Release -D SUPERNOVA=ON -D CMAKE_INSTALL_PREFIX=$INSTALL_PATH -D IN_PLACE_BUILD=OFF ..
     - name: build
       shell: bash
       working-directory: ${{ env.BUILD_PATH }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,8 @@ jobs:
         include:
           - name: Linux-x64
             os: ubuntu-18.04
+            cmake-flags: '-G "Unix Makefiles" -D RULE_LAUNCH_COMPILE=ccache'
+            cache-path: '~/.ccache'
             
           - name: macOS
             os: macos-10.15
@@ -77,6 +79,13 @@ jobs:
         repository: supercollider/supercollider
         path: ${{ env.SC_SRC_PATH }}
         ref: main
+    - name: cache ccache
+      uses: actions/cache@v2
+      if: matrix.cache-path
+      with:
+        path: ${{ matrix.cache-path }}
+        key: ${{ matrix.name }}-${{ github.run_id }}
+        restore-keys: ${{ matrix.name }}-
     - name: install Linux dependencies
       if: runner.os == 'Linux'
       run: sudo apt-get install --yes libfftw3-dev

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,14 +93,14 @@ jobs:
       if: matrix.vcvars-script
       shell: cmd
       working-directory: ${{ env.FFTW_INSTALL_DIR }}
-      env:
-        DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer'
-        MACOSX_DEPLOYMENT_TARGET: '${{ matrix.deployment-target }}'
       run: |
         call "${{ matrix.vcvars-script }}"
         lib.exe /machine:${{ matrix.fftw-arch }} /def:libfftw3f-3.def
     - name: configure
       shell: bash
+      env:
+        DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer'
+        MACOSX_DEPLOYMENT_TARGET: '${{ matrix.deployment-target }}'
       run: |
         mkdir $BUILD_PATH && cd $BUILD_PATH
         GENERATOR="${{ matrix.cmake-generator }}"


### PR DESCRIPTION
I was working on adding ccache caching to our build system and made a number of changes/improvements along the way:
- Linux ~~and macOS~~ builds use ccache now
- ~~macOS generator was swtiched to "Unix Makefiles" since the "XCode" generator needs extra commands in CMakeLists to use ccache, see [CMakeLists in SC](https://github.com/supercollider/supercollider/blob/develop/CMakeLists.txt#L42-L66)~~
  - ~~**is it OK to switch to Makefiles generator? Or should we stick to XCode generator and not care about cache for now?**~~
  - After the dev meeting on Dec 4, 2021 we've decided to go back to XCode and not use ccache on macOS
- I've simplified the yaml file by moving platform-dependent cmake switches directly to the matrix entries to avoid extra logic to handle various configurations
- I've made the main CI action not to run on website changes
- Windows build does not use ccache as we can't use ccache with MSVC, AFAIU
- I removed "-VS" from the Windows build artifacts' names