### PR TITLE
create universal macOS binaries

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,6 +65,8 @@ jobs:
       BUILD_PATH: ${{ github.workspace }}/build
       INSTALL_PATH: ${{ github.workspace }}/build/install
       FFTW_INSTALL_DIR: "C:/Program Files/fftw"
+      DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer'
+      MACOSX_DEPLOYMENT_TARGET: '${{ matrix.deployment-target }}'
 
     name: ${{ matrix.name }}
     steps:
@@ -115,9 +117,6 @@ jobs:
         lib.exe /machine:${{ matrix.fftw-arch }} /def:libfftw3f-3.def
     - name: configure
       shell: bash
-      env:
-        DEVELOPER_DIR: '/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer'
-        MACOSX_DEPLOYMENT_TARGET: '${{ matrix.deployment-target }}'
       run: |
         mkdir $BUILD_PATH && cd $BUILD_PATH
         cmake ${{ matrix.cmake-flags }} -D SC_PATH=$SC_SRC_PATH -D CMAKE_BUILD_TYPE=Release -D SUPERNOVA=ON -D CMAKE_INSTALL_PREFIX=$INSTALL_PATH -D IN_PLACE_BUILD=OFF ..

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         include:
           - name: Linux-x64
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             cmake-flags: '-G "Unix Makefiles" -D RULE_LAUNCH_COMPILE=ccache'
             cache-path: '~/.ccache'
             

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,9 +41,9 @@ jobs:
             cache-path: '~/.ccache'
             
           - name: macOS
-            os: macos-10.15
-            cmake-flags: '-G Xcode'
-            xcode-version: '10.3'
+            os: macos-11
+            cmake-flags: '-G Xcode -D CMAKE_OSX_ARCHITECTURES="x86_64;arm64"'
+            xcode-version: '12.4'
             deployment-target: '10.10'
             
           - name: Windows-32bit


### PR DESCRIPTION
As we are getting ready to offer macOS binaries for both x86_64 and arm64 platforms, I tried enabling universal macOS builds for sc3-plugins as well.

I tested this briefly by booting scsynth and running an example from `Tartini`'s helpfile, and - after un-quarantining - the plugins worked on both arm64 machine with macOS 12 as well as x86_64 machine with macOS 10.10... full compatibility range.

I also updated Xcode version to match the main SC release and made some minor cosmetic updates to the CI.