### PR TITLE
3.13.0-rc1 updates

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -1,3 +1,4 @@
+- tag: Version-3.13.0-rc1
 - tag: Version-3.11.1
 - tag: Version-3.11.0
 - tag: Version-3.11.0-rc2

--- a/package/create_package.sh
+++ b/package/create_package.sh
@@ -51,9 +51,10 @@ move_sources() {
 
 sign_sources() {
   cd "${output_dir}"
-  gpg2 --default-key "${signer}" \
-       --output "${package_name}-${version}-Source.tar.bz2.asc" \
-       --detach-sign "${package_name}-${version}-Source.tar.bz2"
+  gpg --detach-sign \
+      -u "${signer}" \
+      -o "${package_name}-${version}-Source.tar.bz2.asc" \
+      "${package_name}-${version}-Source.tar.bz2"
 }
 
 cleanup_source_dir() {


### PR DESCRIPTION
Here are two unrelated updates:
- update gpg command to match the one in the main SuperCollider repo (I used it to create signature for 3.13.0-rc1 source package)
- add the latest tag so that it is linked on the sc3-plugins website