### PR TITLE
Replace int with size_t

### DIFF
--- a/source/HOAUGens/HOAAzimuthRotator1.cpp
+++ b/source/HOAUGens/HOAAzimuthRotator1.cpp
@@ -920,7 +920,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAAzimuthRotator10.cpp
+++ b/source/HOAUGens/HOAAzimuthRotator10.cpp
@@ -2369,7 +2369,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAAzimuthRotator2.cpp
+++ b/source/HOAUGens/HOAAzimuthRotator2.cpp
@@ -985,7 +985,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAAzimuthRotator3.cpp
+++ b/source/HOAUGens/HOAAzimuthRotator3.cpp
@@ -1074,7 +1074,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAAzimuthRotator4.cpp
+++ b/source/HOAUGens/HOAAzimuthRotator4.cpp
@@ -1187,7 +1187,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAAzimuthRotator5.cpp
+++ b/source/HOAUGens/HOAAzimuthRotator5.cpp
@@ -1324,7 +1324,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAAzimuthRotator6.cpp
+++ b/source/HOAUGens/HOAAzimuthRotator6.cpp
@@ -1485,7 +1485,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAAzimuthRotator7.cpp
+++ b/source/HOAUGens/HOAAzimuthRotator7.cpp
@@ -1670,7 +1670,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAAzimuthRotator8.cpp
+++ b/source/HOAUGens/HOAAzimuthRotator8.cpp
@@ -1879,7 +1879,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAAzimuthRotator9.cpp
+++ b/source/HOAUGens/HOAAzimuthRotator9.cpp
@@ -2112,7 +2112,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamDirac2HOA1.cpp
+++ b/source/HOAUGens/HOABeamDirac2HOA1.cpp
@@ -1037,7 +1037,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamDirac2HOA10.cpp
+++ b/source/HOAUGens/HOABeamDirac2HOA10.cpp
@@ -3324,7 +3324,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamDirac2HOA2.cpp
+++ b/source/HOAUGens/HOABeamDirac2HOA2.cpp
@@ -1129,7 +1129,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamDirac2HOA3.cpp
+++ b/source/HOAUGens/HOABeamDirac2HOA3.cpp
@@ -1268,7 +1268,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamDirac2HOA4.cpp
+++ b/source/HOAUGens/HOABeamDirac2HOA4.cpp
@@ -1446,7 +1446,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamDirac2HOA5.cpp
+++ b/source/HOAUGens/HOABeamDirac2HOA5.cpp
@@ -1659,7 +1659,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamDirac2HOA6.cpp
+++ b/source/HOAUGens/HOABeamDirac2HOA6.cpp
@@ -1915,7 +1915,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamDirac2HOA7.cpp
+++ b/source/HOAUGens/HOABeamDirac2HOA7.cpp
@@ -2202,7 +2202,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamDirac2HOA8.cpp
+++ b/source/HOAUGens/HOABeamDirac2HOA8.cpp
@@ -2543,7 +2543,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamDirac2HOA9.cpp
+++ b/source/HOAUGens/HOABeamDirac2HOA9.cpp
@@ -2909,7 +2909,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamHCardio2HOA1.cpp
+++ b/source/HOAUGens/HOABeamHCardio2HOA1.cpp
@@ -1170,7 +1170,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamHCardio2HOA2.cpp
+++ b/source/HOAUGens/HOABeamHCardio2HOA2.cpp
@@ -1406,7 +1406,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamHCardio2HOA3.cpp
+++ b/source/HOAUGens/HOABeamHCardio2HOA3.cpp
@@ -1732,7 +1732,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamHCardio2Mono1.cpp
+++ b/source/HOAUGens/HOABeamHCardio2Mono1.cpp
@@ -1024,7 +1024,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamHCardio2Mono2.cpp
+++ b/source/HOAUGens/HOABeamHCardio2Mono2.cpp
@@ -1147,7 +1147,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOABeamHCardio2Mono3.cpp
+++ b/source/HOAUGens/HOABeamHCardio2Mono3.cpp
@@ -1330,7 +1330,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d1.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d1.cpp
@@ -1038,7 +1038,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d10.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d10.cpp
@@ -5637,7 +5637,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d2.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d2.cpp
@@ -1237,7 +1237,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d3.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d3.cpp
@@ -1514,7 +1514,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d4.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d4.cpp
@@ -1869,7 +1869,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d5.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d5.cpp
@@ -2302,7 +2302,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d6.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d6.cpp
@@ -2813,7 +2813,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d7.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d7.cpp
@@ -3402,7 +3402,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d8.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d8.cpp
@@ -4069,7 +4069,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d9.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2AcnSn3d9.cpp
@@ -4814,7 +4814,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2FuMa1.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2FuMa1.cpp
@@ -1041,7 +1041,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2FuMa2.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2FuMa2.cpp
@@ -1240,7 +1240,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnN3d2FuMa3.cpp
+++ b/source/HOAUGens/HOAConverterAcnN3d2FuMa3.cpp
@@ -1517,7 +1517,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnSn3d2FuMa1.cpp
+++ b/source/HOAUGens/HOAConverterAcnSn3d2FuMa1.cpp
@@ -1038,7 +1038,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnSn3d2FuMa2.cpp
+++ b/source/HOAUGens/HOAConverterAcnSn3d2FuMa2.cpp
@@ -1236,7 +1236,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterAcnSn3d2FuMa3.cpp
+++ b/source/HOAUGens/HOAConverterAcnSn3d2FuMa3.cpp
@@ -1512,7 +1512,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterFuma2AcnN3d1.cpp
+++ b/source/HOAUGens/HOAConverterFuma2AcnN3d1.cpp
@@ -1041,7 +1041,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterFuma2AcnN3d2.cpp
+++ b/source/HOAUGens/HOAConverterFuma2AcnN3d2.cpp
@@ -1240,7 +1240,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterFuma2AcnN3d3.cpp
+++ b/source/HOAUGens/HOAConverterFuma2AcnN3d3.cpp
@@ -1517,7 +1517,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterFuma2AcnSn3d1.cpp
+++ b/source/HOAUGens/HOAConverterFuma2AcnSn3d1.cpp
@@ -1038,7 +1038,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterFuma2AcnSn3d2.cpp
+++ b/source/HOAUGens/HOAConverterFuma2AcnSn3d2.cpp
@@ -1236,7 +1236,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAConverterFuma2AcnSn3d3.cpp
+++ b/source/HOAUGens/HOAConverterFuma2AcnSn3d3.cpp
@@ -1512,7 +1512,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOADecBinaural1.cpp
+++ b/source/HOAUGens/HOADecBinaural1.cpp
@@ -1050,7 +1050,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOADecBinaural2.cpp
+++ b/source/HOAUGens/HOADecBinaural2.cpp
@@ -1177,7 +1177,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOADecLebedev061.cpp
+++ b/source/HOAUGens/HOADecLebedev061.cpp
@@ -1201,7 +1201,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOADecLebedev261.cpp
+++ b/source/HOAUGens/HOADecLebedev261.cpp
@@ -1657,7 +1657,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOADecLebedev262.cpp
+++ b/source/HOAUGens/HOADecLebedev262.cpp
@@ -1956,7 +1956,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOADecLebedev263.cpp
+++ b/source/HOAUGens/HOADecLebedev263.cpp
@@ -2510,7 +2510,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOADecLebedev501.cpp
+++ b/source/HOAUGens/HOADecLebedev501.cpp
@@ -2213,7 +2213,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOADecLebedev502.cpp
+++ b/source/HOAUGens/HOADecLebedev502.cpp
@@ -2643,7 +2643,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOADecLebedev503.cpp
+++ b/source/HOAUGens/HOADecLebedev503.cpp
@@ -3419,7 +3419,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOADecLebedev504.cpp
+++ b/source/HOAUGens/HOADecLebedev504.cpp
@@ -4492,7 +4492,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOADecLebedev505.cpp
+++ b/source/HOAUGens/HOADecLebedev505.cpp
@@ -5991,7 +5991,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncEigenMike1.cpp
+++ b/source/HOAUGens/HOAEncEigenMike1.cpp
@@ -1494,7 +1494,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncEigenMike2.cpp
+++ b/source/HOAUGens/HOAEncEigenMike2.cpp
@@ -1659,7 +1659,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncEigenMike3.cpp
+++ b/source/HOAUGens/HOAEncEigenMike3.cpp
@@ -1934,7 +1934,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncEigenMike4.cpp
+++ b/source/HOAUGens/HOAEncEigenMike4.cpp
@@ -2682,7 +2682,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncLebedev501.cpp
+++ b/source/HOAUGens/HOAEncLebedev501.cpp
@@ -1314,7 +1314,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncLebedev502.cpp
+++ b/source/HOAUGens/HOAEncLebedev502.cpp
@@ -1590,7 +1590,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncLebedev503.cpp
+++ b/source/HOAUGens/HOAEncLebedev503.cpp
@@ -2074,7 +2074,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncLebedev504.cpp
+++ b/source/HOAUGens/HOAEncLebedev504.cpp
@@ -2729,7 +2729,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncLebedev505.cpp
+++ b/source/HOAUGens/HOAEncLebedev505.cpp
@@ -3570,7 +3570,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncoder1.cpp
+++ b/source/HOAUGens/HOAEncoder1.cpp
@@ -1070,7 +1070,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncoder2.cpp
+++ b/source/HOAUGens/HOAEncoder2.cpp
@@ -1254,7 +1254,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncoder3.cpp
+++ b/source/HOAUGens/HOAEncoder3.cpp
@@ -1512,7 +1512,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncoder4.cpp
+++ b/source/HOAUGens/HOAEncoder4.cpp
@@ -1844,7 +1844,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAEncoder5.cpp
+++ b/source/HOAUGens/HOAEncoder5.cpp
@@ -2248,7 +2248,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAMirror1.cpp
+++ b/source/HOAUGens/HOAMirror1.cpp
@@ -928,7 +928,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAMirror10.cpp
+++ b/source/HOAUGens/HOAMirror10.cpp
@@ -2566,7 +2566,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAMirror2.cpp
+++ b/source/HOAUGens/HOAMirror2.cpp
@@ -998,7 +998,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAMirror3.cpp
+++ b/source/HOAUGens/HOAMirror3.cpp
@@ -1096,7 +1096,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAMirror4.cpp
+++ b/source/HOAUGens/HOAMirror4.cpp
@@ -1222,7 +1222,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAMirror5.cpp
+++ b/source/HOAUGens/HOAMirror5.cpp
@@ -1376,7 +1376,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAMirror6.cpp
+++ b/source/HOAUGens/HOAMirror6.cpp
@@ -1558,7 +1558,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAMirror7.cpp
+++ b/source/HOAUGens/HOAMirror7.cpp
@@ -1768,7 +1768,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAMirror8.cpp
+++ b/source/HOAUGens/HOAMirror8.cpp
@@ -2006,7 +2006,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAMirror9.cpp
+++ b/source/HOAUGens/HOAMirror9.cpp
@@ -2272,7 +2272,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAPanLebedev061.cpp
+++ b/source/HOAUGens/HOAPanLebedev061.cpp
@@ -1138,7 +1138,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAPanLebedev261.cpp
+++ b/source/HOAUGens/HOAPanLebedev261.cpp
@@ -1596,7 +1596,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAPanLebedev262.cpp
+++ b/source/HOAUGens/HOAPanLebedev262.cpp
@@ -1730,7 +1730,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAPanLebedev263.cpp
+++ b/source/HOAUGens/HOAPanLebedev263.cpp
@@ -1887,7 +1887,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAPanLebedev501.cpp
+++ b/source/HOAUGens/HOAPanLebedev501.cpp
@@ -2147,7 +2147,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAPanLebedev502.cpp
+++ b/source/HOAUGens/HOAPanLebedev502.cpp
@@ -2329,7 +2329,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAPanLebedev503.cpp
+++ b/source/HOAUGens/HOAPanLebedev503.cpp
@@ -2507,7 +2507,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAPanLebedev504.cpp
+++ b/source/HOAUGens/HOAPanLebedev504.cpp
@@ -2813,7 +2813,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOAPanLebedev505.cpp
+++ b/source/HOAUGens/HOAPanLebedev505.cpp
@@ -3112,7 +3112,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOARotator1.cpp
+++ b/source/HOAUGens/HOARotator1.cpp
@@ -941,7 +941,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOARotator2.cpp
+++ b/source/HOAUGens/HOARotator2.cpp
@@ -1048,7 +1048,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOARotator3.cpp
+++ b/source/HOAUGens/HOARotator3.cpp
@@ -1234,7 +1234,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;

--- a/source/HOAUGens/HOARotator4.cpp
+++ b/source/HOAUGens/HOARotator4.cpp
@@ -1525,7 +1525,7 @@ inline static void Faust_updateControls(Faust* unit)
     Control* controls = unit->mControls;
     size_t numControls = unit->mNumControls;
     int curControl = unit->mDSP->getNumInputs();
-    for (int i = 0; i < numControls; ++i) {
+    for (size_t i = 0; i < numControls; ++i) {
         float value = IN0(curControl);
         (controls++)->update(value);
         curControl++;


### PR DESCRIPTION
Enable consistent comparison and prevent error
messages such as:
 warning: comparison of integer expressions of
 different signedness: 'int' and 'size_t'
 {aka 'long unsigned int'} [-Wsign-compare]

Addresses https://github.com/supercollider/sc3-plugins/issues/346