### PR TITLE
GHA: remove ._ files from macOS zip

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,6 +136,9 @@ jobs:
         else
           zip -r ${{ steps.set-filename.outputs.filename }}.zip .
         fi
+        if [[ "${{ runner.os }}" == "macOS" ]]; then
+          zip -d ${{ steps.set-filename.outputs.filename }}.zip \*/._\*
+        fi
     - name: upload artifacts
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
To get rid of these errors when starting scsynth:

*** ERROR: dlopen '[...]/Extensions/sc3-plugins/SC3plugins/AYUGens/._AY_UGen.scx'
err 'dlopen([...]/Extensions/sc3-plugins/SC3plugins/AYUGens/._AY_UGen.scx, 2): no suitable image found.
Did find: [...]/Extensions/sc3-plugins/SC3plugins/AYUGens/._AY_UGen.scx: file too short
