### PR TITLE
Bump to macos 14 in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,9 +41,9 @@ jobs:
             cache-path: '~/.ccache'
             
           - name: macOS
-            os: macos-11
+            os: macos-14
             cmake-flags: '-G Xcode -D CMAKE_OSX_ARCHITECTURES="x86_64;arm64"'
-            xcode-version: '12.4'
+            xcode-version: '15.3'
             deployment-target: '10.10'
             
           - name: Windows-32bit


### PR DESCRIPTION
As mentioned in #379 

Interestingly enough, the macOS artifact zip does not have `._` files in it?