### PR TITLE
GHA: update runners to newer versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,8 +35,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux-x64
+          - name: Linux-x64-22.04
             os: ubuntu-22.04
+            cmake-flags: '-G "Unix Makefiles" -D RULE_LAUNCH_COMPILE=ccache'
+            cache-path: '~/.ccache'
+
+          - name: Linux-x64-24.04
+            os: ubuntu-24.04
             cmake-flags: '-G "Unix Makefiles" -D RULE_LAUNCH_COMPILE=ccache'
             cache-path: '~/.ccache'
             

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,27 +36,27 @@ jobs:
       matrix:
         include:
           - name: Linux-x64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             cmake-flags: '-G "Unix Makefiles" -D RULE_LAUNCH_COMPILE=ccache'
             cache-path: '~/.ccache'
             
           - name: macOS
             os: macos-14
             cmake-flags: '-G Xcode -D CMAKE_OSX_ARCHITECTURES="x86_64;arm64"'
-            xcode-version: '15.3'
-            deployment-target: '10.10'
+            xcode-version: '15.4'
+            deployment-target: '10.15'
             
           - name: Windows-32bit
-            os: windows-2019
-            cmake-flags: '-G "Visual Studio 16 2019" -A Win32'
-            vcvars-script: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars32.bat'
+            os: windows-2022
+            cmake-flags: '-G "Visual Studio 17 2022" -A Win32'
+            vcvars-script: 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat'
             fftw-url: 'ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip'
             fftw-arch: 'X86'
             
           - name: Windows-64bit
-            os: windows-2019
-            cmake-flags: '-G "Visual Studio 16 2019" -A x64'
-            vcvars-script: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat'
+            os: windows-2022
+            cmake-flags: '-G "Visual Studio 17 2022" -A x64'
+            vcvars-script: 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat'
             fftw-url: 'ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip'
             fftw-arch: 'X64'
 


### PR DESCRIPTION
Inspired by the recent macOS runner update, I thought it would be nice to update other runners to newer versions. 
These changes might be preceding the changes to SC's CI, but I'm pretty sure that by the time we are ready for the 3.14 release, we'll be using at least these versions of the deployment tools.