### PR TITLE
CI: Update jekyll.yml to Ubuntu 24.04

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     name: 'jekyll build'
     env:
       # use BUNDLE_ env vars to set 'bundle config' options

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: 'jekyll build'
     env:
       # use BUNDLE_ env vars to set 'bundle config' options

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -10,6 +10,7 @@ on:
       - '_config.yml'
       - 'Gemfile*'
       - 'README.md'
+      - '.github/**'
 
 jobs:
   build:


### PR DESCRIPTION
Ubuntu 20.04 images are being removed, let's upgrade...

FYI Jekyll build is set up so that changes to the website can be checked against the build system.