### PR TITLE
Help: Explain PV_Morph = polar interp and PV_XFade = Cartesian interp

### DIFF
--- a/source/BhobUGens/sc/HelpSource/Classes/PV_Morph.schelp
+++ b/source/BhobUGens/sc/HelpSource/Classes/PV_Morph.schelp
@@ -6,7 +6,7 @@ categories:: UGens>FFT
 
 Description::
 
-Morphs between two fft buffers.
+Morphs between two fft buffers by interpolating each bin's polar coordinates.
 
 classmethods::
 

--- a/source/BhobUGens/sc/HelpSource/Classes/PV_XFade.schelp
+++ b/source/BhobUGens/sc/HelpSource/Classes/PV_XFade.schelp
@@ -6,7 +6,7 @@ categories:: UGens>FFT
 
 Description::
 
-Interpolates bins between two fft buffers.
+Interpolates bins between two fft buffers by interpolating each bin's complex (Cartesian) coordinates.
 
 
 classmethods::


### PR DESCRIPTION
Even though we're "not maintaining" sc3-plugins... every time I need to use PV_Morph or PV_XFade, I always have to look it up in the C++ source code to find out which one it is Cartesian and which one is polar. This really should be in the help, but isn't: "Morphs between two fft buffers" and "Interpolates bins between two fft buffers" leaves too much to the imagination.