### PR TITLE
[ci] update filename setting step's output format

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,7 +86,7 @@ jobs:
         else
           VERSION=$GITHUB_SHA
         fi
-        echo "::set-output name=filename::sc3-plugins-$VERSION-${{ matrix.name }}"
+        echo "filename=sc3-plugins-$VERSION-${{ matrix.name }}" >> $GITHUB_OUTPUT
     - name: checkout sc3-plugins
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
This updates the workflow to remove the warning ```The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. ```