### PR TITLE
build: fix/add ccache support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,19 +38,20 @@ jobs:
         include:
           - name: Linux-x64-22.04
             os: ubuntu-22.04
-            cmake-flags: '-G "Unix Makefiles" -D RULE_LAUNCH_COMPILE=ccache'
-            cache-path: '~/.ccache'
+            cmake-flags: '-G "Unix Makefiles"'
+            cache-path: '~/.cache/ccache'
 
           - name: Linux-x64-24.04
             os: ubuntu-24.04
-            cmake-flags: '-G "Unix Makefiles" -D RULE_LAUNCH_COMPILE=ccache'
-            cache-path: '~/.ccache'
+            cmake-flags: '-G "Unix Makefiles"'
+            cache-path: '~/.cache/ccache'
             
           - name: macOS
             os: macos-14
             cmake-flags: '-G Xcode -D CMAKE_OSX_ARCHITECTURES="x86_64;arm64"'
             xcode-version: '15.4'
             deployment-target: '10.15'
+            cache-path: '~/Library/Caches/ccache'
             
           - name: Windows-32bit
             os: windows-2022
@@ -58,6 +59,7 @@ jobs:
             vcvars-script: 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars32.bat'
             fftw-url: 'ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll32.zip'
             fftw-arch: 'X86'
+            cache-path: '~/AppData/Local/ccache'
             
           - name: Windows-64bit
             os: windows-2022
@@ -65,6 +67,7 @@ jobs:
             vcvars-script: 'C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat'
             fftw-url: 'ftp://ftp.fftw.org/pub/fftw/fftw-3.3.5-dll64.zip'
             fftw-arch: 'X64'
+            cache-path: '~/AppData/Local/ccache'
 
     env:
       SC_SRC_PATH: ${{ github.workspace }}/supercollider
@@ -106,7 +109,16 @@ jobs:
         restore-keys: ${{ matrix.name }}-
     - name: install Linux dependencies
       if: runner.os == 'Linux'
-      run: sudo apt-get install --yes libfftw3-dev
+      run: sudo apt-get install --yes libfftw3-dev ccache
+    - name: install macOS dependencies
+      if: runner.os == 'macOS'
+      run: brew install ccache
+    - name: install Windows dependencies
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        choco install ccache --no-progress
+        echo "`echo c:/ProgramData/chocolatey/lib/ccache/tools/ccache*`" >> $GITHUB_PATH # put the direct path before the path of the choco's "shim" (link substitute)
     - name: install FFTW
       if: runner.os == 'Windows'
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ option(NATIVE "Optimize for this specific machine." OFF)
 option(SYSTEM_STK "Use STK libraries from system" OFF)
 option(HOA_UGENS "Build with HOAUGens (Higher-order Ambisonics)" ON)
 option(NOVA_DISK_IO "Build with Nova's DiskIO UGens (experimental). Requires SuperCollider source code." OFF)
+option(USE_CCACHE "Use ccache if available." ON)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
 	set(CMAKE_COMPILER_IS_CLANG 1)
@@ -143,6 +144,65 @@ endif()
 # all plugins directories in the dmg root)
 if (APPLE AND OSX_PACKAGE)
   set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/build_osx")
+endif()
+
+############################################
+# Detect CCache
+
+if(USE_CCACHE)
+
+  # find ccache
+  find_program(CCACHE_PROGRAM ccache)
+
+  if(CCACHE_PROGRAM)
+
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+
+    if (MSVC)
+      # workaround for Visual Studio adapted from https://github.com/ccache/ccache/wiki/MS-Visual-Studio#usage
+      # NOTE: there is an issue with ccache installed from chocolatey
+      # since chocolatey puts a "shim" as opposed to the actual executable in the PATH
+      # the solution is to add the path to the actual ccache executable earlier in the path
+      # e.g. in bash: export PATH=`echo c:/ProgramData/chocolatey/lib/ccache/tools/ccache*`:$PATH
+      message(STATUS "Found ccache at ${CCACHE_PROGRAM}: using ccache with MSVC to speed up build process")
+
+      file(COPY_FILE
+        ${CCACHE_PROGRAM} ${CMAKE_BINARY_DIR}/cl.exe
+        ONLY_IF_DIFFERENT)
+
+      set(CMAKE_VS_GLOBALS
+        "CLToolExe=cl.exe"
+        "CLToolPath=${CMAKE_BINARY_DIR}"
+        "TrackFileAccess=false"
+        "UseMultiToolTask=true"
+        "DebugInformationFormat=OldStyle"
+      )
+    else()
+      if(CMAKE_GENERATOR STREQUAL "Xcode")
+        message(STATUS "Found ccache at ${CCACHE_PROGRAM}: using ccache with Xcode to speed up build process")
+
+        # workaround for using ccache with Xcode generator
+        # thanks to Craig Scott: https://crascit.com/2016/04/09/using-ccache-with-cmake/
+
+        # Set up wrapper scripts
+        set(SC_LAUNCH_C_SCRIPT   "${CMAKE_BINARY_DIR}/launch-c")
+        set(SC_LAUNCH_CXX_SCRIPT "${CMAKE_BINARY_DIR}/launch-cxx")
+        configure_file("cmake_modules/launch-c.in"   launch-c)
+        configure_file("cmake_modules/launch-cxx.in" launch-cxx)
+        execute_process(COMMAND chmod a+rx "${SC_LAUNCH_C_SCRIPT}" "${SC_LAUNCH_CXX_SCRIPT}")
+
+        # Set Xcode project attributes to route compilation and linking
+        # through our scripts
+        set(CMAKE_XCODE_ATTRIBUTE_CC         "${SC_LAUNCH_C_SCRIPT}")
+        set(CMAKE_XCODE_ATTRIBUTE_CXX        "${SC_LAUNCH_CXX_SCRIPT}")
+        set(CMAKE_XCODE_ATTRIBUTE_LD         "${SC_LAUNCH_C_SCRIPT}")
+        set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${SC_LAUNCH_CXX_SCRIPT}")
+      else()
+        message(STATUS "Found ccache at ${CCACHE_PROGRAM}: using ccache to speed up build process")
+      endif() # Xcode
+    endif() # MSVC
+  endif() # ccache found
 endif()
 
 add_subdirectory(source)

--- a/cmake_modules/launch-c.in
+++ b/cmake_modules/launch-c.in
@@ -1,0 +1,5 @@
+#!/bin/sh
+# thanks to Craig Scott: https://crascit.com/2016/04/09/using-ccache-with-cmake/
+
+export CCACHE_CPP2=true
+exec "${CCACHE_PROGRAM}" "${CMAKE_C_COMPILER}" "$@"

--- a/cmake_modules/launch-cxx.in
+++ b/cmake_modules/launch-cxx.in
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Thanks to Craig Scott: https://crascit.com/2016/04/09/using-ccache-with-cmake/
+
+export CCACHE_CPP2=true
+exec "${CCACHE_PROGRAM}" "${CMAKE_CXX_COMPILER}" "$@"


### PR DESCRIPTION
This PR copies ccache implementation from Supercollider, adding logic to CMakeLists.txt and fixing/adding entries in the CI.

Previously ccache was partially enabled for Linux only, but it didn't work lately, probably due to updated ccache location and possibly updated cmake logic.

Tested here:  https://github.com/dyfer/sc3-plugins/actions/runs/17883065855 (total build time: 2'50"; without ccache it's about 8')

With this repo being rarely updated, the cache is prone to expire, but in the rare instances where there are multiple pushes in shorter succession, tgus improves build times dramatically.