### PR TITLE
set plugin extension to .scx on all platforms

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -133,12 +133,8 @@ set(plugins "")
 set(supernova_plugins "")
 
 set(CMAKE_SHARED_MODULE_PREFIX "")
-set(PLUGIN_EXTENSION ".so")
-
-if (APPLE OR WIN32)
-    set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
-    set(PLUGIN_EXTENSION ".scx")
-endif()
+set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
+set(PLUGIN_EXTENSION ".scx")
 
 
 GET_GCC_VERSION(gcc_version)


### PR DESCRIPTION
in SC 3.15 the .so extension will be deprecated.