### PR TITLE
Update cmake project version setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required (VERSION 3.12)
-set(SUPERNOVA_CMAKE_MINVERSION 3.1)
 project (sc3-plugins)
 
 set(NOVA_SIMD_MISSING_ERROR "The nova-simd source code is missing in \
@@ -57,11 +56,7 @@ include("${SC_PATH}/SCVersion.txt")
 set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH}")
 message(STATUS "Building plugins for SuperCollider version: ${PROJECT_VERSION}")
 
-if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT CMAKE_VERSION VERSION_LESS SUPERNOVA_CMAKE_MINVERSION)
-	option(SUPERNOVA "Build plugins for supernova" ON)
-else()
-	option(SUPERNOVA "Build plugins for supernova" OFF)
-endif()
+option(SUPERNOVA "Build plugins for supernova" ON)
 
 option(AY "Build with AY ugens" ON)
 option(LADSPA "Build with Ladspa ugen" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,18 @@
 cmake_minimum_required (VERSION 3.12)
-project (sc3-plugins)
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules
+                      ${CMAKE_MODULE_PATH})
+
+find_package(SuperCollider3)
+if (NOT SC_FOUND)
+	message(SEND_ERROR "cannot find SuperCollider3 headers. Set the variable SC_PATH.")
+else()
+	message(STATUS "Using SC source located at ${SC_PATH}")
+endif()
+
+include("${SC_PATH}/SCVersion.txt")
+project (sc3-plugins VERSION ${SC_VERSION_MAJOR}.${SC_VERSION_MINOR}.${SC_VERSION_PATCH})
+message(STATUS "Building plugins for SuperCollider version: ${SC_VERSION}")
 
 set(NOVA_SIMD_MISSING_ERROR "The nova-simd source code is missing in \
 ${CMAKE_CURRENT_SOURCE_DIR}/external_libraries/nova-simd.\n This probably \
@@ -21,9 +34,6 @@ if (NOT SYSTEM_STK)
   endif()
 endif()
 
-set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules
-                      ${CMAKE_MODULE_PATH})
-
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/cmake_uninstall.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
@@ -31,13 +41,6 @@ configure_file(
 
 add_custom_target(uninstall
   "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
-
-find_package(SuperCollider3)
-if (NOT SC_FOUND)
-	message(SEND_ERROR "cannot find SuperCollider3 headers. Set the variable SC_PATH.")
-else()
-	message(STATUS "Using SC source located at ${SC_PATH}")
-endif()
 
 set(NOVA_TT_MISSING_ERROR "The nova-tt source code is missing in \
 ${SC_PATH}/external_libraries/nova-tt.\n Make sure to point to a valid version \
@@ -51,10 +54,6 @@ if (NOVA_DISK_IO)
     message(FATAL_ERROR "${NOVA_TT_MISSING_ERROR}")
   endif()
 endif()
-
-include("${SC_PATH}/SCVersion.txt")
-set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}${PROJECT_VERSION_PATCH}")
-message(STATUS "Building plugins for SuperCollider version: ${PROJECT_VERSION}")
 
 option(SUPERNOVA "Build plugins for supernova" ON)
 
@@ -229,11 +228,6 @@ endif()
 
 #############################################
 # CPack support
-
-set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
 
 if(WIN32)
     set(CPACK_GENERATOR ZIP)


### PR DESCRIPTION
We have [removed](https://github.com/supercollider/supercollider/pull/7352) old `PROJECT_VERSION_MAJOR` etc variables in the main SC repo after version 3.14. This PR switches to use the currently used `SC_` variables.

Note that I had to move some lines around, particularly adding modules and checking for SC source, in order to set the project's version early on in the file.

I have not tested changes to the cpack part, but 1) I'm not sure we use this functionality and 2) the version for cpack should be set automatically from the project version.

The new version indicators for the project do not include the "tweak" part (e.g. "-rc1"), except for posting, since cmake does not allow dashes. This is in line with the current implementation in SC's cmake.

I also removed different cmake version setting for supernova and switched it on by default on all platforms (similarly to the current setting in SC). 