### PR TITLE
cmake: use .so extension on Linux when building against older versions of SuperCollider

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -134,7 +134,9 @@ set(supernova_plugins "")
 
 set(CMAKE_SHARED_MODULE_PREFIX "")
 set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
-set(PLUGIN_EXTENSION ".scx")
+if(NOT WIN32 AND NOT APPLE AND (NOT DEFINED SC_VERSION OR SC_VERSION VERSION_LESS "3.15"))
+    set(CMAKE_SHARED_MODULE_SUFFIX ".so") # before SC 3.15, SuperCollider on *nix expected plugins to have .so extension
+endif()
 
 
 GET_GCC_VERSION(gcc_version)


### PR DESCRIPTION
This brings back the .so extension on Linux/*nix when building sc3-plugins against SC 3.14 and lower (including the current stable branch). It will also default to .so on *nix if `SC_VERSION` cannot be found (e.g. in SC before version 3.11). `SC_VERSION` is defined in [SCVersion.txt](https://github.com/supercollider/supercollider/blob/develop/SCVersion.txt) in the SC sources.
BTW I used the `SC_VERSION` variable which clearly relates to SC, and not to the version of the plugins, regardless of what we decide in #429 in terms of versioning and using `PROJECT_VERSION` moving forward.

This change was previously discussed in https://github.com/supercollider/sc3-plugins/pull/428#issuecomment-4417503909

Additionally, I removed the `PLUGIN_EXTENSION` variable, as it doesn't seem to be used anywhere.