### PR TITLE
cmake: update plugin extension for StkInst

### DIFF
--- a/source/StkInst/CMakeLists.txt
+++ b/source/StkInst/CMakeLists.txt
@@ -40,8 +40,9 @@ include_directories(${SC_PATH}/external_libraries/libsndfile/)
 
 
 set(CMAKE_SHARED_MODULE_PREFIX "")
-if(APPLE OR WIN32)
-    set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
+set(CMAKE_SHARED_MODULE_SUFFIX ".scx")
+if(NOT WIN32 AND NOT APPLE AND (NOT DEFINED SC_VERSION OR SC_VERSION VERSION_LESS "3.15"))
+    set(CMAKE_SHARED_MODULE_SUFFIX ".so") # before SC 3.15, SuperCollider on *nix expected plugins to have .so extension
 endif()
     
 add_library(${PROJECT} MODULE ${PROJECT}.cpp ${STKSources})


### PR DESCRIPTION
StkInst seems to have its own CMakeFile.

In case the plugin is built separately, I updated the extension handling, in line with the main CMakeLists.txt file. Is that the best way to go here?