### PR TITLE
fix AY freq-to-tone calculation

### DIFF
--- a/source/AYUGens/sc/AY.sc
+++ b/source/AYUGens/sc/AY.sc
@@ -16,9 +16,11 @@ AY : UGen {
 
 	*categories { ^ #["UGens>Oscillators"] }
 
-	*freqtotone { |freq|
-		// Approximate empirical...
-		//^(109300 / (freq - 3.70727))
-		^(110300 / (freq - 0.5))
+	*freqtotone { |freq, sampleRate|
+		var chipTactsPerOutCount;
+		sampleRate = sampleRate ?? { Server.default.sampleRate };
+		// this mirrors ayemu's internal calculation of ChipTacts_per_outcount
+		chipTactsPerOutCount = 1773400.div(sampleRate).div(8);
+		^(sampleRate * chipTactsPerOutCount / (2 * freq)).round
 	}
 }

--- a/source/AYUGens/sc/HelpSource/Classes/AY.schelp
+++ b/source/AYUGens/sc/HelpSource/Classes/AY.schelp
@@ -99,6 +99,12 @@ general add controls for the resulting signal
 METHOD::freqtotone
 converts a frequency value to something appropriate for the strong::tonea::, strong::toneb:: and strong::tonec:: inputs.
 
+ARGUMENT::freq
+the frequency value in Hertz.
+
+ARGUMENT::sampleRate
+sample rate for the frequency conversion. default is strong::Server.default.sampleRate::.
+
 EXAMPLES::
 
 CODE::


### PR DESCRIPTION
fixes #348, and by extension https://codeberg.org/musikinformatik/SuperDirt/issues/281

`AY.freqtotone` is implemented with an "approximate empirical" formula:

https://github.com/supercollider/sc3-plugins/blob/1c9bb5208887781efee925e6d7b9e52a7260d572/source/AYUGens/sc/AY.sc#L19-L23

it is reasonably accurate at a sample rate of 44100 Hz, but at other rates it is severely out of tune.

i noticed that the ayemu code calculates a value `ChipTacts_per_outcount`, which depends on the chip frequency of the emulator as well as the sample rate:

https://github.com/supercollider/sc3-plugins/blob/1c9bb5208887781efee925e6d7b9e52a7260d572/source/AYUGens/AY_libayemu/src/ay8912.c#L369

the `AY_Ctor` constructor does not set the chip frequency:

https://github.com/supercollider/sc3-plugins/blob/1c9bb5208887781efee925e6d7b9e52a7260d572/source/AYUGens/AY_UGen.cpp#L49-L51

therefore we fall back to the default frequency of `1773400`, defined here:

https://github.com/supercollider/sc3-plugins/blob/1c9bb5208887781efee925e6d7b9e52a7260d572/source/AYUGens/AY_libayemu/src/ay8912.c#L17

so, some real-world values of `ChipTacts_per_outcount` are: (keeping in mind this is all integer division)

`1773400/44100/8 = 5`  
`1773400/48000/8 = 4`  
`1773400/96000/8 = 2`

now we can start to see where the magic number `110300` in `freqtotone` comes from; it is very close to `44100*5/2 = 110250`. this hints at a general formula for the conversion constant: 

`sampleRate * chipTacts_per_outcount / 2`

and indeed, this formula seems to work :) notes now sound in tune at both 44100 and 48000 Hz sample rates. (though due to the integer calculations, i guess there will always be some error.)

the PR just implements this calculation in `AY.freqtotone`.
